### PR TITLE
Add UserID to MasterUserRecord and UserAccount

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -15,6 +15,9 @@ type MasterUserRecordSpec struct {
 	// Desired state of the user record: approved|banned|deactivated
 	State string `json:"state,omitempty"`
 
+	// UserID is the user ID from RHD Identity Provider token (“sub” claim)
+	UserID string `json:"userID"`
+
 	// The list of user accounts in the member clusters which belong to this MasterUserRecord
 	UserAccounts []UserAccountEmbedded `json:"userAccounts,omitempty"`
 }

--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -12,6 +12,10 @@ type UserAccountSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
+	// UserID is the user ID from RHD Identity Provider token (“sub” claim)
+	// Is to be used to create Identity and UserIdentityMapping resources
+	UserID string `json:"userID"`
+
 	// The namespace limit name
 	NSLimit string `json:"nsLimit"`
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -100,6 +100,13 @@ func schema_pkg_apis_toolchain_v1alpha1_MasterUserRecordSpec(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"userID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UserID is the user ID from RHD Identity Provider token (“sub” claim)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"userAccounts": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The list of user accounts in the member clusters which belong to this MasterUserRecord",
@@ -114,6 +121,7 @@ func schema_pkg_apis_toolchain_v1alpha1_MasterUserRecordSpec(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"userID"},
 			},
 		},
 		Dependencies: []string{
@@ -399,6 +407,13 @@ func schema_pkg_apis_toolchain_v1alpha1_UserAccountSpec(ref common.ReferenceCall
 			SchemaProps: spec.SchemaProps{
 				Description: "UserAccountSpec defines the desired state of UserAccount",
 				Properties: map[string]spec.Schema{
+					"userID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UserID is the user ID from RHD Identity Provider token (“sub” claim) Is to be used to create Identity and UserIdentityMapping resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"nsLimit": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The namespace limit name",
@@ -413,7 +428,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserAccountSpec(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"nsLimit", "nsTemplateSet"},
+				Required: []string{"userID", "nsLimit", "nsTemplateSet"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
We need **UserID** to create **Identity** and **UserIdentityMapping** resources.