### PR TITLE
add useracc status const

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -6,6 +6,11 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	StatusProvisioning string = "provisioning"
+	StatusProvisioned  string = "provisioned"
+)
+
 // UserAccountSpec defines the desired state of UserAccount
 // +k8s:openapi-gen=true
 type UserAccountSpec struct {


### PR DESCRIPTION
Two status constant added for UserAccount.  "provisioning" and "provisioned".
This will be used by member-operator/UserAccCtrl in PR https://github.com/codeready-toolchain/member-operator/pull/20