### PR TITLE
Rename ResourceVersion to SyncIndex in MasterUserRecord

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -27,8 +27,9 @@ type UserAccountEmbedded struct {
 	// The cluster in which the user exists
 	TargetCluster string `json:"targetCluster"`
 
-	// The resource version of the corresponding UserAccount
-	ResourceVersion string `json:"resourceVersion"`
+	// SyncIndex is to be updated by UserAccount Controller
+	// when the member needs to trigger MasterUserRecord <-> UserAccount(s) synchronization
+	SyncIndex string `json:"syncIndex"`
 
 	// The spec of the corresponding UserAccount
 	Spec UserAccountSpec `json:"spec"`


### PR DESCRIPTION
We are supposed to use this field only as a marker to initiate the status sync between MasterUserRecord and the corresponding UserAccount.
We still can use ResourceVersion as actual value when updating this field but we don't really care what value we set. Also it may happen that because of multiple concurrent reconciles the field will point to some outdated UserAccount resource version. Which is totally fine. So, to avoid potential confusion with the name let's rename it to `SyncIndex`.