### PR TITLE
Preserve custom fields in crds

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -88,6 +88,7 @@ type UserAccountStatusEmbedded struct {
 // MasterUserRecord is the Schema for the masteruserrecords API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=mur
 type MasterUserRecord struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -47,6 +47,12 @@ type UserAccountStatus struct {
 // UserAccount is the Schema for the useraccounts API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=".spec.userID",priority=1
+// +kubebuilder:printcolumn:name="NS Limit",type="string",JSONPath=".spec.nsLimit"
+// +kubebuilder:printcolumn:name="Tier Name",type="string",JSONPath=".spec.nsTemplateSet.tierName"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].reason"
+// +kubebuilder:printcolumn:name="Disabled",type="boolean",JSONPath=".spec.disabled",priority=1
 type UserAccount struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -54,6 +54,12 @@ type UserSignupStatus struct {
 // UserSignup is the Schema for the usersignup API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=".spec.userID",priority=1
+// +kubebuilder:printcolumn:name="TargetCluster",type="string",JSONPath=".spec.targetCluster",priority=1
+// +kubebuilder:printcolumn:name="Complete",type="string",JSONPath=".status.conditions[?(@.type==\"Complete\")].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Complete\")].reason"
+// +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=".status.conditions[?(@.type==\"Approved\")].status",priority=1
+// +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=".status.conditions[?(@.type==\"Approved\")].reason",priority=1
 type UserSignup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
use 'kubebuilder' build flags to specify extra
fields in the generated CRDs, namely for:
- short names
- additional printer columns
    
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>