### PR TITLE
fix printcolumns tags

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -50,8 +50,8 @@ type UserAccountStatus struct {
 // +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=".spec.userID",priority=1
 // +kubebuilder:printcolumn:name="NS Limit",type="string",JSONPath=".spec.nsLimit"
 // +kubebuilder:printcolumn:name="Tier Name",type="string",JSONPath=".spec.nsTemplateSet.tierName"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].reason"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=="Ready")].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=="Ready")].reason"
 // +kubebuilder:printcolumn:name="Disabled",type="boolean",JSONPath=".spec.disabled",priority=1
 type UserAccount struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -56,10 +56,10 @@ type UserSignupStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=".spec.userID",priority=1
 // +kubebuilder:printcolumn:name="TargetCluster",type="string",JSONPath=".spec.targetCluster",priority=1
-// +kubebuilder:printcolumn:name="Complete",type="string",JSONPath=".status.conditions[?(@.type==\"Complete\")].status"
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Complete\")].reason"
-// +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=".status.conditions[?(@.type==\"Approved\")].status",priority=1
-// +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=".status.conditions[?(@.type==\"Approved\")].reason",priority=1
+// +kubebuilder:printcolumn:name="Complete",type="string",JSONPath=".status.conditions[?(@.type=="Complete")].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=="Complete")].reason"
+// +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=".status.conditions[?(@.type=="Approved")].status",priority=1
+// +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=".status.conditions[?(@.type=="Approved")].reason",priority=1
 type UserSignup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
in the generated yaml files, the 'JSONPath' field would
contain backslashes before the quotes, which would cause
errors and prevent the field from being displayed in the
`oc get ...` commands

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

