### PR TITLE
Added username field to UserSignup spec

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -32,6 +32,12 @@ type UserSignupSpec struct {
 	// If not set then the user is subject of auto-approval (if enabled)
 	// +optional
 	Approved bool `json:"approved,omitempty"`
+
+	// The username.  This may differ from the UserSignup's metadata.name, which is restricted by the
+	// limited character set available for naming (see RFC1123).  If the username contains characters which are
+	// disqualified from the resource name, the username is transformed into an acceptable resource name instead.
+	// For example, johnsmith@redhat.com -> johnsmith-at-redhat-com
+	Username string `json:"username"`
 }
 
 // UserSignupStatus defines the observed state of UserSignup

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -61,6 +61,7 @@ type UserSignupStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=".spec.userID",priority=1
+// +kubebuilder:printcolumn:name="Username",type="string",JSONPath=".spec.username",priority=1
 // +kubebuilder:printcolumn:name="TargetCluster",type="string",JSONPath=".spec.targetCluster",priority=1
 // +kubebuilder:printcolumn:name="Complete",type="string",JSONPath=".status.conditions[?(@.type=="Complete")].status"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=="Complete")].reason"

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -568,8 +568,15 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"username": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The username.  This may differ from the UserSignup's metadata.name, which is restricted by the limited character set available for naming (see RFC1123).  If the username contains characters which are disqualified from the resource name, the username is transformed into an acceptable resource name instead. For example, johnsmith@redhat.com -> johnsmith-at-redhat-com",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"userID"},
+				Required: []string{"userID", "username"},
 			},
 		},
 		Dependencies: []string{},


### PR DESCRIPTION
Upstream issue:  https://jira.coreos.com/browse/CRT-225

This PR adds a username field to the `UserSignup` specification.  The username field will contain the original, unaltered username for the user signing up, while the `UserSignup`'s resource name will be set to a transformed version of this username in the case that it contains invalid characters.

