### PR TITLE
chore: add code coverage for tests

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,39 @@
+codecov:
+  max_report_age: "off"  # see https://docs.codecov.io/docs/codecov-yaml#section-expired-reports
+
+# See http://docs.codecov.io/docs/coverage-configuration
+coverage:
+  precision: 2  # 2 = xx.xx%, 0 = xx%
+  round: down
+  # For example: 20...60 would result in any coverage less than 20%
+  # would have a red background. The color would gradually change to
+  # green approaching 60%. Any coverage over 60% would result in a
+  # solid green color.
+  range: "20...60"
+
+  status:
+    # project will give us the diff in the total code coverage between a commit
+    # and its parent
+    project: yes
+    # Patch gives just the coverage of the patch
+    patch: yes
+    # changes tells us if there are unexpected code coverage changes in other files
+    # which were not changed by the diff
+    changes: yes
+
+  # See http://docs.codecov.io/docs/ignoring-paths
+  ignore:
+    - "vendor/*"
+    - "make/*"
+    - "build/*"
+    - "example/*"
+    - "openshift-ci/*"
+
+# See http://docs.codecov.io/docs/pull-request-comments-1
+comment:
+  layout: "header, diff, tree"
+  # default = posts once then update, posts new if delete
+  # once = post once then updates
+  # new = delete old, post new
+  # spammy = post new
+  behavior: "new"

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,8 @@
 = ToolChain API
 
+image:https://goreportcard.com/badge/github.com/codeready-toolchain/api[Go Report Card, link="https://goreportcard.com/report/github.com/codeready-toolchain/api"]
+image:https://codecov.io/gh/codeready-toolchain/api/branch/master/graph/badge.svg[Codecov.io,link="https://codecov.io/gh/codeready-toolchain/api"]
+
 == Building
 CodeReady ToolChain API is built using https://github.com/golang/go/wiki/Modules[Go modules].  Set the following environment variable in your CLI before building:
 
@@ -13,4 +16,4 @@ To re-generate the `zz_generated.deepcopy.go` and `zz_generated.openapi.go` file
 make generate
 ```
 
-NOTE: the `make generate` will generate the CRD files in the local `deploy/crds` directory and then dispatch the `.yaml` files in the `host-operator` and `member-operator` repositories, assuming they have been checked out and that *they are in a clean state*, meaning that they have no pending changes, besides previous versions of the CRD files.  
+NOTE: the `make generate` will generate the CRD files in the local `deploy/crds` directory and then dispatch the `.yaml` files in the `host-operator` and `member-operator` repositories, assuming they have been checked out and that *they are in a clean state*, meaning that they have no pending changes, besides previous versions of the CRD files.

--- a/make/go.mk
+++ b/make/go.mk
@@ -13,12 +13,6 @@ build: $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
 	    go build github.com/codeready-toolchain/api/pkg/apis/
 
-.PHONY: test
-## runs the tests
-test:
-	@echo "running the tests..."
-	$(Q)go test ./...
-
 .PHONY: vendor
 vendor: 
 	$(Q)go mod vendor

--- a/make/out.mk
+++ b/make/out.mk
@@ -1,4 +1,5 @@
-# Create output directory for artifacts and test results. ./out is supposed to
+# Create output directory for artifacts and test results. `./build/_output` is supposed to
 # be a safe place for all targets to write to while knowing that all content
-# inside of ./out is wiped once "make clean" is run.
-$(shell mkdir -p ./out);
+# inside of `./build/_output` is wiped once "make clean" is run.
+OUT_DIR := ./build/_output
+$(shell mkdir -p $(OUT_DIR))

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,0 +1,65 @@
+############################################################
+#
+# (local) Tests
+#
+############################################################
+
+.PHONY: test
+## runs the tests without coverage
+test:
+	@echo "running the tests without coverage..."
+	$(Q)go test ${V_FLAG} -race $(shell go list ./...) -failfast
+
+
+############################################################
+#
+# OpenShift CI Tests with Coverage
+#
+############################################################
+
+# Output directory for coverage information
+COV_DIR = $(OUT_DIR)/coverage
+
+.PHONY: test-with-coverage
+## runs the tests with coverage
+test-with-coverage:
+	@echo "running the tests with coverage..."
+	@-mkdir -p $(COV_DIR)
+	@-rm $(COV_DIR)/coverage.txt
+	$(Q)go test -vet off ${V_FLAG} $(shell go list ./...) -coverprofile=$(COV_DIR)/coverage.txt -covermode=atomic ./...
+
+.PHONY: upload-codecov-report
+# Uploads the test coverage reports to codecov.io. 
+# DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged! 
+upload-codecov-report: 
+	# Upload coverage to codecov.io. Since we don't run on a supported CI platform (Jenkins, Travis-ci, etc.), 
+	# we need to provide the PR metadata explicitely using env vars used coming from https://github.com/openshift/test-infra/blob/master/prow/jobs.md#job-environment-variables
+	# 
+	# Also: not using the `-F unittests` flag for now as it's temporarily disabled in the codecov UI 
+	# (see https://docs.codecov.io/docs/flags#section-flags-in-the-codecov-ui)
+	env
+ifneq ($(PR_COMMIT), null)
+	@echo "uploading test coverage report for pull-request #$(PULL_NUMBER)..."
+	bash <(curl -s https://codecov.io/bash) \
+		-t $(CODECOV_TOKEN) \
+		-f $(COV_DIR)/coverage.txt \
+		-C $(PR_COMMIT) \
+		-r $(REPO_OWNER)/$(REPO_NAME) \
+		-P $(PULL_NUMBER) \
+		-Z
+else
+	@echo "uploading test coverage report after PR was merged..."
+	bash <(curl -s https://codecov.io/bash) \
+		-t $(CODECOV_TOKEN) \
+		-f $(COV_DIR)/coverage.txt \
+		-C $(BASE_COMMIT) \
+		-r $(REPO_OWNER)/$(REPO_NAME) \
+		-Z
+endif
+
+CODECOV_TOKEN := "826c8011-d0bd-4223-b7e9-bc56dae66f3e"
+REPO_OWNER := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].org')
+REPO_NAME := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].repo')
+BASE_COMMIT := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].base_sha')
+PR_COMMIT := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].pulls[0].sha')
+PULL_NUMBER := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].pulls[0].number')


### PR DESCRIPTION
## Description
* moves test target from `go.mk` to `test.mk`
* adds a new target to run tests with coverage
* adds configuration for codecov