### PR TITLE
chore: add crd suffix to CRD file names-it's expected by operator-sdk csv generator

### DIFF
--- a/make/generate.mk
+++ b/make/generate.mk
@@ -72,10 +72,10 @@ generate-crds: vendor prepare-host-operator prepare-member-operator
 	--output-dir deploy/crds
 	@echo "Dispatching CRD files in the 'host-operator' and 'member-operator' repositories..."
 	@for file in $(HOST_CLUSTER_CRD_FILES) ; do \
-		mv deploy/crds/$$file ../host-operator/deploy/crds ; \
+		mv deploy/crds/$$file ../host-operator/deploy/crds/$${file%.yaml}_crd.yaml ; \
 	done
 	@for file in $(MEMBER_CLUSTER_CRD_FILES) ; do \
-		mv deploy/crds/$$file ../member-operator/deploy/crds ; \
+		mv deploy/crds/$$file ../member-operator/deploy/crds/$${file%.yaml}_crd.yaml ; \
 	done
 ifneq ($(wildcard deploy/crds/*.yaml),)
 	@echo "ERROR: some CRD files were not dispatched: $(wildcard deploy/crds/*.yaml)"


### PR DESCRIPTION
## Description
when CRDs are moved after generation, we need to add `_crd` suffix to the file name because it's required by operator-sdk csv generator
see https://github.com/operator-framework/operator-sdk/issues/1980

## Checks
1. Have you run `make generate` target? **[yes/no]**

**Yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]**

**Yes** - just renames the files

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/71
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/69
