### PR TITLE
Short name 'tier' for NSTemplateTier CRD

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
@@ -42,6 +42,7 @@ type NSTemplateTierStatus struct {
 // NSTemplateTier is the Schema for the nstemplatetiers API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=tier
 type NSTemplateTier struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
## Description
This PR adds a short name 'tier' for NSTemplateTier CRD. So we can do `oc get tier`.

## Checks
1. Have you run `make generate` target? **[yes/no]**

Yes.

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]** 

Yes. See https://github.com/codeready-toolchain/host-operator/pull/79
