### PR TITLE
feat(CRT-228): modify script so it creates CSV and hack files for member-operator

### DIFF
--- a/make/generate.mk
+++ b/make/generate.mk
@@ -42,6 +42,7 @@ member_repo_status := $(shell cd ../member-operator && git status -s | grep -v d
 PHONY: generate-csv
 generate-csv:
 	./scripts/olm-catalog.sh -pr ../host-operator
+	./scripts/olm-catalog.sh -pr ../member-operator
 
 PHONY: prepare-host-operator
 prepare-host-operator: ../host-operator

--- a/scripts/olm-catalog.sh
+++ b/scripts/olm-catalog.sh
@@ -60,7 +60,7 @@ CURRENT_CSV_VERSION=${CURRENT_CSV_VERSION:-0.0.0}
 # Files and directories related vars
 PRJ_NAME=`basename ${PRJ_ROOT_DIR}`
 CRDS_DIR=${PRJ_ROOT_DIR}/deploy/crds
-PKG_DIR=${PRJ_ROOT_DIR}/deploy/olm-catalog/host-operator
+PKG_DIR=${PRJ_ROOT_DIR}/deploy/olm-catalog/${PRJ_NAME}
 PKG_FILE=${PKG_DIR}/${PRJ_NAME}.package.yaml
 CSV_DIR=${PKG_DIR}/${NEXT_CSV_VERSION}
 
@@ -132,7 +132,7 @@ metadata:
 spec:
   channel: alpha
   installPlanApproval: Automatic
-  name: host-operator
+  name: ${PRJ_NAME}
   source: ${NAME}
   sourceNamespace: openshift-marketplace
   startingCSV: ${PRJ_NAME}.v0.0.1" > ${PRJ_ROOT_DIR}/hack/install_operator.yaml


### PR DESCRIPTION
## Description
It modifies the script as well as the target so it creates CSV and hack files for member-operator repo

## Checks
1. Have you run `make generate` target? **[yes/no]**
**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
**yes**

3. In case other projects are changed, please provides PR links.
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/77
