### PR TITLE
configure golangci-lint new timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,10 @@
+service:
+  project-path: github.com/codeready-toolchain/api
+
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
+
 linters:
   enable:
     - gofmt


### PR DESCRIPTION
## Description
Configure the `timeout` value to 10min in `.golangci.yml`

## Checks
1. Have you run `make generate` target? **no**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **no** 

## Notes

fixes CRT-298

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
