### PR TITLE
chore(CRT-331): rename operators to toolchain-host-operator and toolchain-member-operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,10 @@ image:https://goreportcard.com/badge/github.com/codeready-toolchain/api[Go Repor
 image:https://codecov.io/gh/codeready-toolchain/api/branch/master/graph/badge.svg[Codecov.io,link="https://codecov.io/gh/codeready-toolchain/api"]
 
 == Building
-Requires Go version 1.13 - download for your development environment https://golang.org/dl/[here].
+Requires:
+
+* Go version 1.13 - download for your development environment https://golang.org/dl/[here].
+* Operator-sdk version 0.11.0 - download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
 
 CodeReady ToolChain API is built using https://github.com/golang/go/wiki/Modules[Go modules].  Set the following environment variable in your CLI before building:
 

--- a/scripts/olm-catalog.sh
+++ b/scripts/olm-catalog.sh
@@ -59,24 +59,25 @@ CURRENT_CSV_VERSION=${CURRENT_CSV_VERSION:-0.0.0}
 
 # Files and directories related vars
 PRJ_NAME=`basename ${PRJ_ROOT_DIR}`
+OPERATOR_NAME=toolchain-${PRJ_NAME}
 CRDS_DIR=${PRJ_ROOT_DIR}/deploy/crds
-PKG_DIR=${PRJ_ROOT_DIR}/deploy/olm-catalog/${PRJ_NAME}
-PKG_FILE=${PKG_DIR}/${PRJ_NAME}.package.yaml
+PKG_DIR=${PRJ_ROOT_DIR}/deploy/olm-catalog/${OPERATOR_NAME}
+PKG_FILE=${PKG_DIR}/${OPERATOR_NAME}.package.yaml
 CSV_DIR=${PKG_DIR}/${NEXT_CSV_VERSION}
 
 # Name and display name vars for CatalogSource
-NAME=codeready-toolchain-saas-${PRJ_NAME}
+NAME=codeready-toolchain-saas-${OPERATOR_NAME}
 DISPLAYNAME=$(echo ${NAME} | tr '-' ' ' | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
 
 # Generate CSV
 CURRENT_DIR=${PWD}
 cd ${PRJ_ROOT_DIR}
-operator-sdk olm-catalog gen-csv --csv-version ${NEXT_CSV_VERSION} --from-version ${CURRENT_CSV_VERSION} --update-crds
+operator-sdk olm-catalog gen-csv --csv-version ${NEXT_CSV_VERSION} --from-version ${CURRENT_CSV_VERSION} --update-crds --operator-name ${OPERATOR_NAME}
 cd ${CURRENT_DIR}
 
 # If the CSV was generated from default "template" version 0.0.0, then remove the delete clause
-TMP_CSV="/tmp/${PRJ_NAME}_${NEXT_CSV_VERSION}_csv"
-sed "/  replaces: ${PRJ_NAME}.v0.0.0$/d" ${CSV_DIR}/*clusterserviceversion.yaml > ${TMP_CSV}
+TMP_CSV="/tmp/${OPERATOR_NAME}_${NEXT_CSV_VERSION}_csv"
+sed "/  replaces: ${OPERATOR_NAME}.v0.0.0$/d" ${CSV_DIR}/*clusterserviceversion.yaml > ${TMP_CSV}
 sed '/^[ ]*$/d' ${TMP_CSV} > ${CSV_DIR}/*clusterserviceversion.yaml
 rm -rf ${TMP_CSV}
 
@@ -132,7 +133,7 @@ metadata:
 spec:
   channel: alpha
   installPlanApproval: Automatic
-  name: ${PRJ_NAME}
+  name: ${OPERATOR_NAME}
   source: ${NAME}
   sourceNamespace: openshift-marketplace
-  startingCSV: ${PRJ_NAME}.v0.0.1" > ${PRJ_ROOT_DIR}/hack/install_operator.yaml
+  startingCSV: ${OPERATOR_NAME}.v0.0.1" > ${PRJ_ROOT_DIR}/hack/install_operator.yaml


### PR DESCRIPTION
## Description
we cannot have package and repository with the same name in quay and because the images are already pushed to `member-operator` and `host-operator` repositories, we need to rename the operators to be able to push the bundles to `toolchain-member-operator` and `toolchain-host-operator` packages

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/95
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/86
