### PR TITLE
chore: drop 0.0.0 csv template thanks to operator-sdk 0.11.0

### DIFF
--- a/scripts/olm-catalog.sh
+++ b/scripts/olm-catalog.sh
@@ -55,7 +55,6 @@ fi
 
 # Version vars
 NEXT_CSV_VERSION=${NEXT_CSV_VERSION:-0.0.1}
-CURRENT_CSV_VERSION=${CURRENT_CSV_VERSION:-0.0.0}
 
 # Files and directories related vars
 PRJ_NAME=`basename ${PRJ_ROOT_DIR}`
@@ -70,16 +69,14 @@ NAME=codeready-toolchain-saas-${OPERATOR_NAME}
 DISPLAYNAME=$(echo ${NAME} | tr '-' ' ' | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
 
 # Generate CSV
+if [[ -n "${CURRENT_CSV_VERSION}" ]]; then
+    FROM_VERSION_PARAM=--from-version ${CURRENT_CSV_VERSION}
+fi
+
 CURRENT_DIR=${PWD}
 cd ${PRJ_ROOT_DIR}
-operator-sdk olm-catalog gen-csv --csv-version ${NEXT_CSV_VERSION} --from-version ${CURRENT_CSV_VERSION} --update-crds --operator-name ${OPERATOR_NAME}
+operator-sdk olm-catalog gen-csv --csv-version ${NEXT_CSV_VERSION} ${FROM_VERSION_PARAM} --update-crds --operator-name ${OPERATOR_NAME}
 cd ${CURRENT_DIR}
-
-# If the CSV was generated from default "template" version 0.0.0, then remove the delete clause
-TMP_CSV="/tmp/${OPERATOR_NAME}_${NEXT_CSV_VERSION}_csv"
-sed "/  replaces: ${OPERATOR_NAME}.v0.0.0$/d" ${CSV_DIR}/*clusterserviceversion.yaml > ${TMP_CSV}
-sed '/^[ ]*$/d' ${TMP_CSV} > ${CSV_DIR}/*clusterserviceversion.yaml
-rm -rf ${TMP_CSV}
 
 # Create hack directory if is missing
 if [[ ! -d ${PRJ_ROOT_DIR}/hack ]]; then


### PR DESCRIPTION
## Description
Drop  0.0.0 csv templates thanks to operator-sdk 0.11.0 as the generation of CSV works properly

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/97
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/88
