### PR TITLE
fix: grep shouldn't fail when doesn't find replace clause & improve help

### DIFF
--- a/scripts/olm-catalog-generate.sh
+++ b/scripts/olm-catalog-generate.sh
@@ -2,6 +2,19 @@
 
 OLM_SETUP_FILE=./scripts/olm-setup.sh
 
+additional_help() {
+    echo "Examples:"
+    echo "   ./scripts/olm-catalog-generate.sh -pr ../host-operator"
+    echo "          - This command will (re)generate CSV, CRDs and package info with a default version \"${DEFAULT_VERSION}\" for host-operator project"
+    echo ""
+    echo "   ./scripts/olm-catalog-generate.sh -nv 0.2.0 -pr ../host-operator"
+    echo "          - This command will (re)generate CSV, CRDs and package info with the version 0.2.0 for host-operator project"
+    echo ""
+    echo "   ./scripts/olm-catalog-generate.sh -ch beta -tv 0.0.1 -nv 0.2.0 -rv 0.1.0 -pr ../host-operator   "
+    echo "          - This command will (re)generate CSV, CRDs and package info for host-operator project with the version 0.2.0 and channel beta,"
+    echo "            as a base version for the generation will use CSV 0.0.1 and will add into the new CSV a replace clause for the version 0.1.0"
+}
+
 if [[ -f ${OLM_SETUP_FILE} ]]; then
     source ${OLM_SETUP_FILE}
 else

--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -11,6 +11,9 @@ user_help () {
     echo "-nv, --next-version      Semantic version of the new CSV to be created"
     echo "-rv, --replace-version   The CSV version to be replaced by the new version (this param has to be specified even if it's same as template-version)"
     echo "-ch, --channel           Channel to be used for the CSV in the package manifest"
+    echo "-h,  --help              To show this help text"
+    echo ""
+    additional_help 2>/dev/null || true
     exit 0
 }
 
@@ -65,9 +68,12 @@ read_arguments() {
     fi
 }
 
+# Default version var - it has to be out of the function to make it available in help text
+DEFAULT_VERSION=0.0.1
+
 setup_variables() {
     # Version vars
-    NEXT_CSV_VERSION=${NEXT_CSV_VERSION:-0.0.1}
+    NEXT_CSV_VERSION=${NEXT_CSV_VERSION:-${DEFAULT_VERSION}}
 
     # Channel to be used
     CHANNEL=${CHANNEL:alpha}
@@ -98,7 +104,7 @@ generate_bundle() {
     operator-sdk olm-catalog gen-csv --csv-version ${NEXT_CSV_VERSION} --update-crds --operator-name ${OPERATOR_NAME} ${FROM_VERSION_PARAM} ${CHANNEL_PARAM}
     cd ${CURRENT_DIR}
 
-    CURRENT_REPLACE_CLAUSE=`grep "replaces:" ${CSV_DIR}/*clusterserviceversion.yaml`
+    CURRENT_REPLACE_CLAUSE=`grep "replaces:" ${CSV_DIR}/*clusterserviceversion.yaml || true`
     if [[ -n "${REPLACE_VERSION}" ]]; then
         if [[ -n "${TEMPLATE_CSV_VERSION}" ]]; then
             CSV_SED_REPLACE+=";s/replaces: ${OPERATOR_NAME}.v${TEMPLATE_CSV_VERSION}/replaces: ${OPERATOR_NAME}.v${REPLACE_VERSION}/"

--- a/scripts/push-to-quay-nightly.sh
+++ b/scripts/push-to-quay-nightly.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+additional_help() {
+    echo "Important info: push-to-quay-nightly.sh scripts overrides all the parameters but \"--project-root\", so use only that one to specify the root of the project."
+    echo "                The parameters are overridden with these values:"
+    echo "                      --channel nightly"
+    echo "                      --template-version ${DEFAULT_VERSION}"
+    echo "                      --next-version 0.0.<number-of-commits>-<short-sha-of-latest-commit>"
+    echo "                      --replace-version 0.0.<number-of-commits-1>-<short-sha-of-last-but-one-commit>"
+    echo ""
+    echo "                Required variables:"
+    echo "                      QUAY_NAMESPACE  - Quay namespace the operator bundle should be pushed to."
+    echo ""
+    echo "                Optional variables:"
+    echo "                      QUAY_AUTH_TOKEN - Quay authentication token to be used for pushing to the quay namespace. If not set, then it's taken from ~/.docker/config.json file."
+    echo ""
+    echo "Example:"
+    echo "   ./scripts/push-to-quay-nightly.sh -pr ../host-operator"
+    echo "          - This command will generate CSV, CRDs and package info with the values defined above for the host-operator project"
+    echo "            and pushes it to quay namespace defined by \"\${QUAY_NAMESPACE}\" variable."
+
+}
 
 push_to_quay() {
     TMP_FLATTEN_DIR="/tmp/${OPERATOR_NAME}_${NEXT_CSV_VERSION}_flatten"
@@ -44,7 +64,7 @@ NEXT_CSV_VERSION="0.0.$(git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROO
 REPLACE_CSV_VERSION="0.0.$(git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-list --count HEAD^)-${PREVIOUS_GIT_COMMIT_ID}"
 
 #read arguments one more time with the versions set
-read_arguments $@ --channel nightly --template-version 0.0.1 --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}
+read_arguments $@ --channel nightly --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}
 setup_variables
 
 # setup additional variables for pushing images


### PR DESCRIPTION
## Description
* Fix for the grep that was looking for "replace" clause - shouldn't fail when doesn't find replace clause 
* Improve help text by adding additional explanation and examples

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
