### PR TITLE
fix: add missing git community source

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -14,6 +14,7 @@ ENV LANG=en_US.utf8 \
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/api
 
 RUN yum install epel-release -y \
+    && yum install  https://centos7.iuscommunity.org/ius-release.rpm -y \
     && yum install --enablerepo=centosplus install -y --quiet \
     findutils \
     git2u-all \


### PR DESCRIPTION
## Description
add missing git community source

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**

verified (locally) that the git is really installed:
```
$ docker run -it tools
[root@aab285c96a62 api]# git version
git version 2.16.5
[root@aab285c96a62 api]# go version
go version go1.13.4 linux/amd64
```