### PR TITLE
add jq to CI tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -30,6 +30,8 @@ RUN yum install epel-release -y \
     jq \
     && yum clean all
 
+WORKDIR /tmp
+
 # download, verify and install golang
 ENV PATH=$PATH:/usr/local/go/bin
 RUN curl -Lo go1.13.4.linux-amd64.tar.gz https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz \
@@ -41,7 +43,6 @@ RUN curl -Lo go1.13.4.linux-amd64.tar.gz https://dl.google.com/go/go1.13.4.linux
     && go version
 
 # download, verify and install openshift client tools (oc and kubectl)
-WORKDIR /tmp
 RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -o openshift-origin-client-tools.tar.gz \
     && echo "4b0f07428ba854174c58d2e38287e5402964c9a9355f6c359d1242efd0990da3 openshift-origin-client-tools.tar.gz" > openshift-origin-client-tools.sha256 \
     && sha256sum -c openshift-origin-client-tools.sha256 \

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -27,6 +27,7 @@ RUN yum install epel-release -y \
     kubectl \
     yamllint \
     python36-virtualenv \
+    jq \
     && yum clean all
 
 # download, verify and install golang


### PR DESCRIPTION
## Description
Add `jq` to the tools installed in the Docker image used on OpenShift CI

## Checks
1. Have you run `make generate` target? **no**

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

