### PR TITLE
feat(CRT-361): add target copying reg-service deployment to host repo

### DIFF
--- a/make/generate.mk
+++ b/make/generate.mk
@@ -9,7 +9,7 @@ MEMBER_CLUSTER_CRDS:=useraccount nstemplateset
 
 .PHONY: generate
 ## Generate deepcopy, openapi and CRD files after the API was modified
-generate: vendor generate-deepcopy generate-openapi generate-crds generate-csv
+generate: vendor generate-deepcopy generate-openapi generate-crds generate-csv copy-reg-service-deployment
 	
 .PHONY: generate-deepcopy
 generate-deepcopy:
@@ -103,3 +103,7 @@ generate-kubefed-crd: vendor
 	@go install github.com/go-bindata/go-bindata/...
 	@$(GOPATH)/bin/go-bindata -pkg cluster -o ../toolchain-common/pkg/cluster/kubefedcluster_assets.go -nocompress -prefix deploy/crds/kubefed deploy/crds/kubefed
 	@rm -rf deploy/crds/kubefed
+
+.PHONY: copy-reg-service-deployment
+copy-reg-service-deployment:
+	cp ../registration-service/deploy/deployment.yaml ../host-operator/deploy/registration-service/deployment.yaml

--- a/make/generate.mk
+++ b/make/generate.mk
@@ -9,7 +9,7 @@ MEMBER_CLUSTER_CRDS:=useraccount nstemplateset
 
 .PHONY: generate
 ## Generate deepcopy, openapi and CRD files after the API was modified
-generate: vendor generate-deepcopy generate-openapi generate-crds generate-csv copy-reg-service-deployment
+generate: vendor generate-deepcopy generate-openapi generate-crds generate-csv copy-reg-service-template
 	
 .PHONY: generate-deepcopy
 generate-deepcopy:
@@ -104,6 +104,6 @@ generate-kubefed-crd: vendor
 	@$(GOPATH)/bin/go-bindata -pkg cluster -o ../toolchain-common/pkg/cluster/kubefedcluster_assets.go -nocompress -prefix deploy/crds/kubefed deploy/crds/kubefed
 	@rm -rf deploy/crds/kubefed
 
-.PHONY: copy-reg-service-deployment
-copy-reg-service-deployment:
-	cp ../registration-service/deploy/deployment.yaml ../host-operator/deploy/registration-service/deployment.yaml
+.PHONY: copy-reg-service-template
+copy-reg-service-template:
+	cp ../registration-service/deploy/registration-service.yaml ../host-operator/deploy/registration-service/registration-service.yaml


### PR DESCRIPTION
## Description
Add a target that copies the deployment template from registration-service repo to host-operator repo - for more information see:
https://github.com/codeready-toolchain/registration-service/pull/75
https://github.com/codeready-toolchain/host-operator/pull/111

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/111