### PR TITLE
Remove deprecated TargetCluster from MUR status

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -77,14 +77,8 @@ type MasterUserRecordStatus struct {
 
 type UserAccountStatusEmbedded struct {
 
-	// Deprecated! Use Cluster instead
-	// The cluster in which the user exists
-	// +optional
-	TargetCluster string `json:"targetCluster,omitempty"`
-
 	// Cluster is the cluster in which the user exists
-	// +optional
-	Cluster Cluster `json:"cluster,omitempty"`
+	Cluster Cluster `json:"cluster"`
 
 	// SyncIndex is used for checking if there is needed some MasterUserRecord <-> UserAccount
 	// synchronization for this specific UserAccount in the specific member cluster


### PR DESCRIPTION
## Description
Remove deprecated TargetCluster from MUR status

## Checks
1. Have you run `make generate` target? **[yes/no]**

yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 

yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/112
