### PR TITLE
Adding usersignup email

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -10,6 +10,9 @@ const (
 	UserSignupApproved ConditionType = "Approved"
 	// UserSignupComplete means provisioning is complete
 	UserSignupComplete ConditionType = "Complete"
+
+	// UserSignupUserEmailLabelKey is used for the usersignup email annotations key
+	UserSignupUserEmailLabelKey = "toolchain.dev.openshift.com/user-email"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -61,13 +61,14 @@ type UserSignupStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=`.spec.userID`,priority=1
-// +kubebuilder:printcolumn:name="Username",type="string",JSONPath=`.spec.username`,priority=1
+// +kubebuilder:printcolumn:name="Username",type="string",JSONPath=`.spec.username`
 // +kubebuilder:printcolumn:name="TargetCluster",type="string",JSONPath=`.spec.targetCluster`,priority=1
 // +kubebuilder:printcolumn:name="Complete",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].reason`
 // +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].status`,priority=1
 // +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].reason`,priority=1
 // +kubebuilder:printcolumn:name="CompliantUsername",type="string",JSONPath=`.status.compliantUsername`
+// +kubebuilder:printcolumn:name="Email",type="string",JSONPath=`.meta.annotations[?(@.type=="Email")]`
 type UserSignup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -68,7 +68,7 @@ type UserSignupStatus struct {
 // +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].status`,priority=1
 // +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].reason`,priority=1
 // +kubebuilder:printcolumn:name="CompliantUsername",type="string",JSONPath=`.status.compliantUsername`
-// +kubebuilder:printcolumn:name="Email",type="string",JSONPath=`.meta.annotations[?(@.type=="Email")]`
+// +kubebuilder:printcolumn:name="Email",type="string",JSONPath=`.metadata.annotations.toolchain\.dev\.openshift\.com/user-email`
 type UserSignup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -11,8 +11,8 @@ const (
 	// UserSignupComplete means provisioning is complete
 	UserSignupComplete ConditionType = "Complete"
 
-	// UserSignupUserEmailLabelKey is used for the usersignup email annotations key
-	UserSignupUserEmailLabelKey = "toolchain.dev.openshift.com/user-email"
+	// UserSignupUserEmailAnnotationKey is used for the usersignup email annotations key
+	UserSignupUserEmailAnnotationKey = "toolchain.dev.openshift.com/user-email"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
## Description
As an admin, I want to see the user email when approving an account. This makes my work easier as I can see where the user is coming from (e.g. redhat.com).

## Checks
1. Have you run `make generate` target? **[yes/no]**
**Yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
**Yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/115

Relates to: 
jira - https://jira.coreos.com/browse/CRT-374
e2e- codeready-toolchain/toolchain-e2e#55
reg - codeready-toolchain/registration-service#78
