### PR TITLE
fix: rename IMAGE var to IMAGE_IN_CSV to avoid mismatch

### DIFF
--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -126,8 +126,8 @@ generate_bundle() {
             CSV_SED_REPLACE+="/${CURRENT_REPLACE_CLAUSE}$/d"
         fi
     fi
-    if [[ -n "${IMAGE}" ]]; then
-        CSV_SED_REPLACE+=";s|REPLACE_IMAGE|${IMAGE}|g;s|REPLACE_CREATED_AT|$(date -u +%FT%TZ)|g;"
+    if [[ -n "${IMAGE_IN_CSV}" ]]; then
+        CSV_SED_REPLACE+=";s|REPLACE_IMAGE|${IMAGE_IN_CSV}|g;s|REPLACE_CREATED_AT|$(date -u +%FT%TZ)|g;"
     fi
 
     replace_with_sed "${CSV_SED_REPLACE}" "${CSV_DIR}/*clusterserviceversion.yaml"

--- a/scripts/push-to-quay-nightly.sh
+++ b/scripts/push-to-quay-nightly.sh
@@ -69,7 +69,7 @@ setup_variables
 
 # setup additional variables for pushing images
 QUAY_NAMESPACE=${QUAY_NAMESPACE:codeready-toolchain}
-IMAGE=quay.io/${QUAY_NAMESPACE}/${PRJ_NAME}:${GIT_COMMIT_ID}
+IMAGE_IN_CSV=quay.io/${QUAY_NAMESPACE}/${PRJ_NAME}:${GIT_COMMIT_ID}
 
 # create backup of the current operator package directory
 PKG_DIR_BACKUP=/tmp/deploy_olm-catalog_${PRJ_NAME}_backup


### PR DESCRIPTION
## Description
rename IMAGE var to IMAGE_IN_CSV to avoid mismatch - the reason is that in toolchain-operator repo, there is the `IMAGE` variable defined in one makefile, so it replaced the values when it wasn't needed

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**

