### PR TITLE
CRT-373 add Banned property to MasterUserRecord

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -32,6 +32,10 @@ type MasterUserRecordSpec struct {
 	// +optional
 	Disabled bool `json:"disabled,omitempty"`
 
+	// If set to true then the corresponding user has been banned from logging in and accessing their resources
+	// +optional
+	Banned bool `json:"banned,omitempty"`
+
 	// If set to true then the corresponding UserAccount should be deleted
 	// "false" is assumed by default
 	// +optional

--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -113,6 +113,7 @@ type Cluster struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.spec.userAccounts[].targetCluster`
+// +kubebuilder:printcolumn:name="Banned",type="string",JSONPath=`.spec.disabled`,priority=1
 // +kubebuilder:printcolumn:name="Disabled",type="string",JSONPath=`.spec.disabled`,priority=1
 type MasterUserRecord struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -113,7 +113,7 @@ type Cluster struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.spec.userAccounts[].targetCluster`
-// +kubebuilder:printcolumn:name="Banned",type="string",JSONPath=`.spec.disabled`,priority=1
+// +kubebuilder:printcolumn:name="Banned",type="string",JSONPath=`.spec.banned`,priority=1
 // +kubebuilder:printcolumn:name="Disabled",type="string",JSONPath=`.spec.disabled`,priority=1
 type MasterUserRecord struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -113,6 +113,7 @@ type Cluster struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.spec.userAccounts[].targetCluster`
+// +kubebuilder:printcolumn:name="Disabled",type="string",JSONPath=`.spec.disabled`,priority=1
 type MasterUserRecord struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -113,6 +113,13 @@ func schema_pkg_apis_toolchain_v1alpha1_MasterUserRecordSpec(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"banned": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If set to true then the corresponding user has been banned from logging in and accessing their resources",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"deprovisioned": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If set to true then the corresponding UserAccount should be deleted \"false\" is assumed by default",


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
Add Banned property to MasterUserRecord spec.

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/118
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/104

