### PR TITLE
Add Deactivated property to UserSignup

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -33,6 +33,10 @@ type UserSignupSpec struct {
 	// +optional
 	Approved bool `json:"approved,omitempty"`
 
+	// Deactivated is used to deactivate the user.  If not set, then by default the user is active
+	// +optional
+	Deactivated bool `json:"deactivated,omitempty"`
+
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`
 }
@@ -70,6 +74,7 @@ type UserSignupStatus struct {
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].reason`
 // +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].status`,priority=1
 // +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].reason`,priority=1
+// +kubebuilder:printcolumn:name="Deactivated",type="string",JSONPath=`.spec.deactivated`,priority=1
 // +kubebuilder:printcolumn:name="CompliantUsername",type="string",JSONPath=`.status.compliantUsername`
 // +kubebuilder:printcolumn:name="Email",type="string",JSONPath=`.metadata.annotations.toolchain\.dev\.openshift\.com/user-email`
 type UserSignup struct {

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -725,6 +725,13 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"deactivated": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deactivated is used to deactivate the user.  If not set, then by default the user is active",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"username": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The user's username, obtained from the identity provider.",


### PR DESCRIPTION
## Description
This PR adds a new `Deactivated` property to `UserSignup`, which may be used by an Admin to deactivate a user.

https://jira.coreos.com/browse/CRT-386

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/121

