### PR TITLE
Add Che URL to MUR status

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -101,6 +101,10 @@ type Cluster struct {
 
 	// ConsoleURL is the web console URL of the cluster
 	ConsoleURL string `json:"consoleURL"`
+
+	// CheDashboardURL is the Che Dashboard URL of the cluster if Che is installed
+	// +optional
+	CheDashboardURL string `json:"cheDashboardURL,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Description
Add Che URL to MUR status

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/122

