### PR TITLE
feat: add scripts for generating manifests

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+additional_help() {
+    echo "create-release-bundle.sh creates an operator bundle of a given version in <project-root>/manifests directory"
+    echo "Required parameters:"
+    echo "              \"--project-root\"   to specify the root of the project"
+    echo "              \"--next-version\"   to specify the version the operator bundle should be generated for"
+    echo "Optional parameters:"
+    echo "              \"--operator-name\"  to specify the name of the operator"
+    echo ""
+    echo "Example:"
+    echo "   ./scripts/create-release-bundle.sh -pr ../toolchain-operator/ -on codeready-toolchain-operator --next-version 0.1.0"
+    echo "          - This command will generate CSV, CRDs and package info for version 0.1.0 in the project toolchain-operator,"
+    echo "            it will use codeready-toolchain-operator as a name of the operator."
+    echo "            The resulting manifest will be placed in ../toolchain-operator/manifests/0.1.0/ directory"
+
+}
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/olm-setup.sh
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/olm-setup.sh)"
+    fi
+fi
+# read argument to get project root dir
+read_arguments $@
+
+# take the latest version to be replaced
+if [[ -d ${MANIFESTS_DIR} ]]; then
+    LAST_VERSION=`basename $(ls -d manifests/*/ | sort | tail -1)`
+    REPLACE_LAST_VERSION_PARAM="--replace-version ${LAST_VERSION}"
+fi
+
+QUAY_NAMESPACE=codeready-toolchain
+
+# generate manifests
+generate_manifests --channel alpha --template-version ${DEFAULT_VERSION}
+
+# delete the default version that is used as a template
+rm -rf ${PKG_DIR}/${DEFAULT_VERSION}
+
+# copy everything from package dir to manifests
+if [[ ! -d ${MANIFESTS_DIR} ]]; then
+    mkdir -p ${MANIFESTS_DIR}
+fi
+cp -r ${PKG_DIR}/* ${MANIFESTS_DIR}/
+
+# bring back the original operator package directory
+rm -rf ${PKG_DIR}
+cp -r ${PKG_DIR_BACKUP} ${PKG_DIR}
+
+# verify the manifests
+operator-courier --verbose verify ${MANIFESTS_DIR}


### PR DESCRIPTION
## Description
Add script `create-release-bundle.sh` that generates a final manifest files (operator bundle) in project-root/manifests directory
it also slightly refactors the current `push-to-quay-nightly.sh` and `olm-setup.sh` to reuse some code and to share the logic

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
