### PR TITLE
fix: don't add replace clause for the same version

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -32,14 +32,21 @@ read_arguments $@
 
 # take the latest version to be replaced
 if [[ -d ${MANIFESTS_DIR} ]]; then
-    LAST_VERSION=`basename $(ls -d manifests/*/ | sort | tail -1)`
-    REPLACE_LAST_VERSION_PARAM="--replace-version ${LAST_VERSION}"
+    LAST_VERSION=`basename $(ls -d ${MANIFESTS_DIR}/*/ | sort | tail -1)`
+
+    if [[ "${LAST_VERSION}" != "${NEXT_CSV_VERSION}" ]]; then
+        REPLACE_LAST_VERSION_PARAM="--replace-version ${LAST_VERSION}"
+
+    elif [[ `ls -d ${MANIFESTS_DIR}/*/ | wc -l` -ge 2 ]]; then
+        LAST_VERSION=`basename $(ls -d ${MANIFESTS_DIR}/*/ | sort | tail -2 | head -n 1)`
+        REPLACE_LAST_VERSION_PARAM="--replace-version ${LAST_VERSION}"
+    fi
 fi
 
 QUAY_NAMESPACE=codeready-toolchain
 
 # generate manifests
-generate_manifests --channel alpha --template-version ${DEFAULT_VERSION}
+generate_manifests --channel alpha --template-version ${DEFAULT_VERSION} ${REPLACE_LAST_VERSION_PARAM}
 
 # delete the default version that is used as a template
 rm -rf ${PKG_DIR}/${DEFAULT_VERSION}

--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -230,7 +230,7 @@ indent_list() {
 
 generate_manifests() {
     #read arguments and setup variables
-    read_arguments $@ ${REPLACE_LAST_VERSION_PARAM}
+    read_arguments $@
     setup_variables
 
     # setup additional variables for pushing images


### PR DESCRIPTION
## Description
There was a wrong usage of the replace clause when the same release manifest was regenerated. Now it replaces the last manifest, but if the version is the same as the one that is being generated then it replaces the last but one.

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
