### PR TITLE
feat: add script for pushing manifests to quay

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -44,7 +44,7 @@ if [[ -d ${MANIFESTS_DIR} ]]; then
 fi
 
 QUAY_NAMESPACE=codeready-toolchain
-
+GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short origin/master`
 # generate manifests
 generate_manifests --channel alpha --template-version ${DEFAULT_VERSION} ${REPLACE_LAST_VERSION_PARAM}
 

--- a/scripts/push-to-quay-manifests.sh
+++ b/scripts/push-to-quay-manifests.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+additional_help() {
+    echo "push-to-quay-manifests.sh pushes the latest version of operator bundle from <project-root>/manifest directory to quay.io"
+    echo "Required parameters:"
+    echo "              \"--project-root\"   to specify the root of the project"
+    echo "Optional parameters:"
+    echo "              \"--operator-name\"  to specify the name of the operator"
+    echo ""
+    echo "Example:"
+    echo "   ./scripts/push-to-quay-manifests.sh -pr ../toolchain-operator -on codeready-toolchain-operator"
+    echo "          - This command will push the latest version of the operator bundle of codeready-toolchain-operator from ../toolchain-operator/manifests directory to quay.io"
+
+}
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/olm-setup.sh
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/olm-setup.sh)"
+    fi
+fi
+# read argument to get project root dir
+read_arguments $@
+
+# setup version
+NEXT_CSV_VERSION=`basename $(ls -d ${MANIFESTS_DIR}/*/ | sort | tail -1)`
+
+QUAY_NAMESPACE=${QUAY_NAMESPACE:codeready-toolchain}
+
+# read final arguments and setup vars
+read_arguments $@ --channel alpha --next-version ${NEXT_CSV_VERSION}
+setup_variables
+
+# push manifests to quay
+DIR_TO_PUSH=${MANIFESTS_DIR}
+push_to_quay

--- a/scripts/push-to-quay-nightly.sh
+++ b/scripts/push-to-quay-nightly.sh
@@ -21,27 +21,6 @@ additional_help() {
 
 }
 
-push_to_quay() {
-    RELEASE_BACKUP_DIR="/tmp/${OPERATOR_NAME}_${NEXT_CSV_VERSION}_${CHANNEL}"
-
-    echo "## Pushing the OperatorHub package '${OPERATOR_NAME}' to the Quay.io '${QUAY_NAMESPACE}' organization ..."
-
-    echo " - Copy package to backup folder: ${RELEASE_BACKUP_DIR}"
-
-    rm -rf "${RELEASE_BACKUP_DIR}" > /dev/null 2>&1
-    cp -r "${PKG_DIR}" ${RELEASE_BACKUP_DIR}
-
-    echo " - Push flattened files to Quay.io namespace '${QUAY_NAMESPACE}' as version ${NEXT_CSV_VERSION}"
-
-    if [[ -z ${QUAY_AUTH_TOKEN} ]]; then
-        QUAY_AUTH_TOKEN=`cat ~/.docker/config.json | jq -r '.auths["quay.io"].auth'`
-    fi
-
-    operator-courier --verbose push ${RELEASE_BACKUP_DIR} "${QUAY_NAMESPACE}" "${OPERATOR_NAME}" "${NEXT_CSV_VERSION}" "basic ${QUAY_AUTH_TOKEN}"
-
-    echo "-> Operator bundle pushed."
-}
-
 # use the olm-setup as the source
 OLM_SETUP_FILE=scripts/olm-setup.sh
 if [[ -f ${OLM_SETUP_FILE} ]]; then
@@ -68,6 +47,7 @@ QUAY_NAMESPACE=${QUAY_NAMESPACE:codeready-toolchain}
 generate_manifests $@ --channel nightly --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}
 
 # push manifests to quay
+DIR_TO_PUSH=${PKG_DIR}
 push_to_quay
 
 # bring back the original operator package directory


### PR DESCRIPTION
## Description
This PR:
* add script `push-to-quay-manifests.sh` for pushing the latest manifest to quay.io for testing purposes. Consider the flow when we generate the relase manifest and we need to verify that it is working, so we use this script to push it to quay and then verify it in OpenShift
   * I'll create useful makefile targets later
* when the `create-release-bundle.sh` is used, then it takes the latest commit sha from the origin/master. With the previous version it was hard to regenerate it with multiple commits created in a separated branch - it took the sha from HEAD of the branch, but we need the latest commit in master.

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
