### PR TITLE
fix(scripts): don't remove empty lines from CSV

### DIFF
--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -185,7 +185,7 @@ data:
   customResourceDefinitions: |-
 $(for crd in `ls ${CRDS_DIR}/*.yaml`; do cat ${crd} | indent_list; done)
   clusterServiceVersions: |-
-$(cat ${CSV_DIR}/*clusterserviceversion.yaml | indent_list)
+$(cat ${CSV_DIR}/*clusterserviceversion.yaml | indent_list | sed -e 's|^ *$||g')
   packages: |
 $(cat ${PKG_FILE} | indent_list "packageName")" > ${HACK_DIR}/deploy_csv.yaml
 

--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -146,7 +146,7 @@ generate_bundle() {
 replace_with_sed() {
     TMP_CSV="/tmp/${OPERATOR_NAME}_${NEXT_CSV_VERSION}_replace-file"
     sed -e "$1" $2 > ${TMP_CSV}
-    sed '/^[ ]*$/d' ${TMP_CSV} > $2
+    cat ${TMP_CSV} > $2
     rm -rf ${TMP_CSV}
 }
 


### PR DESCRIPTION
## Description
don't remove empty lines from CSV, otherwise, it's not possible to create formated description like this one: https://github.com/codeready-toolchain/toolchain-operator/commit/9782d827cf0c26e1941fce84919eba652bbd3273

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
