### PR TITLE
chore: update openshift/api to release-4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gobuffalo/flect v0.1.6 // indirect
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 // indirect
-	github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible
+	github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190603091049-60506f45cf65 // indirect
 	golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gobuffalo/flect v0.1.6 // indirect
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 // indirect
+	// using 'github.com/openshift/api@release-4.2'
 	github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190603091049-60506f45cf65 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible h1:sMBjLRdoavwnc2khLpIOmBkMPDGRB4sIbhOb8Cx2Uh0=
-github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8 h1:TgTRbDa0hkrDT+HVJMSYizUFjfEr5dPP6vFZNg4bCWw=
+github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Description
update openshift/api to use release-4.2

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/131
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/114
    - toolchain-operator: https://github.com/codeready-toolchain/toolchain-operator/pull/49
