### PR TITLE
chore: api scheme should contain only CRs

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 )
@@ -15,8 +14,6 @@ func init() {
 	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
 	// Register the KubeFed types with the Scheme so the components can map objects to GroupVersionKinds and back
 	AddToSchemes = append(AddToSchemes, v1beta1.SchemeBuilder.AddToScheme)
-	// Register the CustomResourceDefinition types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, extensionsv1.AddToScheme)
 }
 
 // AddToScheme adds all Resources to the Scheme


### PR DESCRIPTION
## Description
The scheme should contain only CRs apis - this will get rid of the last `reflector.go:95: Failed to list`  errors from our logs

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `olm-examples` of the `ClusterServiceVersion` object)

**no but it requires additional changes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/132
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/115
