### PR TITLE
fix: use correct paths when fetching scripts from GH

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -24,7 +24,7 @@ else
     if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
         source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
     else
-        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/olm-setup.sh)"
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/{OLM_SETUP_FILE})"
     fi
 fi
 # read argument to get project root dir

--- a/scripts/olm-catalog-generate.sh
+++ b/scripts/olm-catalog-generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-OLM_SETUP_FILE=./scripts/olm-setup.sh
+OLM_SETUP_FILE=scripts/olm-setup.sh
 
 additional_help() {
     echo "Examples:"
@@ -21,7 +21,7 @@ else
     if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
         source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
     else
-        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/olm-setup.sh)"
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${OLM_SETUP_FILE})"
     fi
 fi
 

--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -182,7 +182,7 @@ enrich-by-envs-from-yaml() {
         if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${ENRICH_BY_ENVS_FROM_YAML} ]]; then
             ${GOPATH}/src/github.com/codeready-toolchain/api/${ENRICH_BY_ENVS_FROM_YAML} $@ > ${ENRICHED_CSV}
         else
-            curl -sSL  https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/generate-deploy-hack.sh | bash -s -- $@ > ${ENRICHED_CSV}
+            curl -sSL  https://raw.githubusercontent.com/codeready-toolchain/api/master/${ENRICH_BY_ENVS_FROM_YAML} | bash -s -- $@ > ${ENRICHED_CSV}
         fi
     fi
     cat ${ENRICHED_CSV} > $1
@@ -243,7 +243,7 @@ generate_deploy_hack() {
         if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${GENERATE_DEPLOY_HACK_FILE} ]]; then
             ${GOPATH}/src/github.com/codeready-toolchain/api/${GENERATE_DEPLOY_HACK_FILE} $@
         else
-            curl -sSL  https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/generate-deploy-hack.sh | bash -s -- $@
+            curl -sSL  https://raw.githubusercontent.com/codeready-toolchain/api/master/${GENERATE_DEPLOY_HACK_FILE} | bash -s -- $@
         fi
     fi
 }

--- a/scripts/push-to-quay-manifests.sh
+++ b/scripts/push-to-quay-manifests.sh
@@ -21,7 +21,7 @@ else
     if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
         source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
     else
-        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/olm-setup.sh)"
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${OLM_SETUP_FILE})"
     fi
 fi
 # read argument to get project root dir

--- a/scripts/push-to-quay-nightly.sh
+++ b/scripts/push-to-quay-nightly.sh
@@ -64,7 +64,7 @@ else
     if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
         source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
     else
-        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/olm-setup.sh)"
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${OLM_SETUP_FILE})"
     fi
 fi
 # read argument to get project root dir


### PR DESCRIPTION
## Description
When the scripts are being fetched from GH location, in one case there was used a wrong path and in order to avoid such cases I replaced the last path of all other paths by a variables too.

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
