### PR TITLE
chore(CRT-427): use digest instead of tag for defining docker images

### DIFF
--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -154,10 +154,14 @@ generate_bundle() {
         fi
     fi
     if [[ -n "${IMAGE_IN_CSV}" ]]; then
-        CSV_SED_REPLACE+=";s|REPLACE_IMAGE|${IMAGE_IN_CSV}|g;s|REPLACE_CREATED_AT|$(date -u +%FT%TZ)|g;"
+        docker pull ${IMAGE_IN_CSV}
+        IMAGE_IN_CSV_DIGEST_FORMAT=`docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_IN_CSV}`
+        CSV_SED_REPLACE+=";s|REPLACE_IMAGE|${IMAGE_IN_CSV_DIGEST_FORMAT}|g;s|REPLACE_CREATED_AT|$(date -u +%FT%TZ)|g;"
     fi
     if [[ -n "${EMBEDDED_REPO_IMAGE}" ]]; then
-        CSV_SED_REPLACE+=";s|${EMBEDDED_REPO_REPLACEMENT}|${EMBEDDED_REPO_IMAGE}|g;"
+        docker pull ${EMBEDDED_REPO_IMAGE}
+        EMBEDDED_REPO_IMAGE_DIGEST_FORMAT=`docker inspect --format='{{index .RepoDigests 0}}' ${EMBEDDED_REPO_IMAGE}`
+        CSV_SED_REPLACE+=";s|${EMBEDDED_REPO_REPLACEMENT}|${EMBEDDED_REPO_IMAGE_DIGEST_FORMAT}|g;"
     fi
     CSV_LOCATION=${CSV_DIR}/*clusterserviceversion.yaml
     replace_with_sed "${CSV_SED_REPLACE}" "${CSV_LOCATION}"


### PR DESCRIPTION
## Description
Use digest instead of tag for defining docker images while generating CSV. The reason is the air-gapped installation of operators. see: https://docs.openshift.com/container-platform/4.2/operators/olm-restricted-networks.html

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
