### PR TITLE
chore: add olm.skipRange for nightly releases

### DIFF
--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -159,6 +159,9 @@ generate_bundle() {
     if [[ -n "${EMBEDDED_REPO_IMAGE}" ]]; then
         CSV_SED_REPLACE+=";s|${EMBEDDED_REPO_REPLACEMENT}|${EMBEDDED_REPO_IMAGE}|g;"
     fi
+    if [[ "${CHANNEL}" == "nightly" ]]; then
+        CSV_SED_REPLACE+=";s|  annotations:|  annotations:\n    olm.skipRange: '<${NEXT_CSV_VERSION}'|g;"
+    fi
     CSV_LOCATION=${CSV_DIR}/*clusterserviceversion.yaml
     replace_with_sed "${CSV_SED_REPLACE}" "${CSV_LOCATION}"
 


### PR DESCRIPTION
## Description
There are blocked OLM upgrades of host-operator - the reason is that OS didn't properly fetch some of the CSV versions and then it wasn't able to build the whole path of all replacements. In order to avoid it in the future, we will add `olm.skipRange` annotation so OLM will skip the versions that were not fetched.

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**