### PR TITLE
CRT-396 add a label key for UserSignup email hash value

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -14,6 +14,9 @@ const (
 
 	// UserSignupUserEmailAnnotationKey is used for the usersignup email annotations key
 	UserSignupUserEmailAnnotationKey = LabelKeyPrefix + "user-email"
+
+	// UserSignupUserEmailHashAnnotationKey is used for the usersignup email hash annotations key
+	UserSignupUserEmailHashAnnotationKey = LabelKeyPrefix + "email-hash"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
Introduce a new email hash constant for UserSignup instead of using the BannedUser constant.

## Checks
1. Have you run `make generate` target? **[n/a]**

This PR simply introduces a new constant, `UserSignupUserEmailHashAnnotationKey` and makes no structural changes to any CRD.
