### PR TITLE
Fix the naming of constant UserSignupUserEmailHashLabelKey

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -15,8 +15,8 @@ const (
 	// UserSignupUserEmailAnnotationKey is used for the usersignup email annotations key
 	UserSignupUserEmailAnnotationKey = LabelKeyPrefix + "user-email"
 
-	// UserSignupUserEmailHashAnnotationKey is used for the usersignup email hash annotations key
-	UserSignupUserEmailHashAnnotationKey = LabelKeyPrefix + "email-hash"
+	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
+	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
This PR updates the constant name `UserSignupUserEmailHashAnnotationKey` to the more correct `UserSignupUserEmailHashLabelKey`.  (The value is a label, not an annotation).

## Checks
1. Have you run `make generate` target? **[no]**

This PR has no structural changes, and simply renames a constant.