### PR TITLE
feat: add possibility to specify quay namespace via parameter

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -43,7 +43,6 @@ if [[ -d ${MANIFESTS_DIR} ]]; then
     fi
 fi
 
-QUAY_NAMESPACE=codeready-toolchain
 GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short origin/master`
 # generate manifests
 count_images_and_generate_manifests --channel alpha --template-version ${DEFAULT_VERSION} ${REPLACE_LAST_VERSION_PARAM}

--- a/scripts/push-to-quay-manifests.sh
+++ b/scripts/push-to-quay-manifests.sh
@@ -30,8 +30,6 @@ read_arguments $@
 # setup version
 NEXT_CSV_VERSION=`basename $(ls -d ${MANIFESTS_DIR}/*/ | sort | tail -1)`
 
-QUAY_NAMESPACE=${QUAY_NAMESPACE:codeready-toolchain}
-
 # read final arguments and setup vars
 read_arguments $@ --channel alpha --next-version ${NEXT_CSV_VERSION}
 setup_variables

--- a/scripts/push-to-quay-nightly.sh
+++ b/scripts/push-to-quay-nightly.sh
@@ -8,8 +8,8 @@ additional_help() {
     echo "                      --next-version 0.0.<number-of-commits>-<short-sha-of-latest-commit>"
     echo "                      --replace-version 0.0.<number-of-commits-1>-<short-sha-of-last-but-one-commit>"
     echo ""
-    echo "                Required variables:"
-    echo "                      QUAY_NAMESPACE  - Quay namespace the operator bundle should be pushed to."
+    echo "                Variables overrides:"
+    echo "                      QUAY_NAMESPACE  - If this variables is set then you don't have to use the --quay-namespace parameter."
     echo ""
     echo "                Optional variables:"
     echo "                      QUAY_AUTH_TOKEN - Quay authentication token to be used for pushing to the quay namespace. If not set, then it's taken from ~/.docker/config.json file."
@@ -17,7 +17,7 @@ additional_help() {
     echo "Example:"
     echo "   ./scripts/push-to-quay-nightly.sh -pr ../host-operator"
     echo "          - This command will generate CSV, CRDs and package info with the values defined above for the host-operator project"
-    echo "            and pushes it to quay namespace defined by \"\${QUAY_NAMESPACE}\" variable."
+    echo "            and pushes it to quay namespace defined by either \"\${QUAY_NAMESPACE}\" variable or --quay-namespace parameter."
 }
 
 setup_version_variables() {
@@ -72,8 +72,6 @@ read_arguments $@
 
 # setup version and commit variables
 setup_version_variables
-
-QUAY_NAMESPACE=${QUAY_NAMESPACE:codeready-toolchain}
 
 # generate manifests
 count_images_and_generate_manifests $@ --channel nightly --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}


### PR DESCRIPTION
## Description
Adds parameter `--quay-namespace` - if not used then either content of `QUAY_NAMESPACE` env variable or the default value `codeready-toolchain` is used 
This is preparation for running CD builds via OpenShift Pipelines

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**no**
