### PR TITLE
removing deprecated fields disabled and userid from useraccountspecem…

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -85,18 +85,6 @@ type UserAccountSpecEmbedded struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	// UserID is the user ID from RHD Identity Provider token (“sub” claim)
-	// Is to be used to create Identity and UserIdentityMapping resources. This field
-	// is duplicated and will be removed in the future.
-	// +optional
-	UserID string `json:"userID"`
-
-	// If set to true then the corresponding user should not be able to login
-	// "false" is assumed by default. This field is duplicated and will be
-	// removed in the future.
-	// +optional
-	Disabled bool `json:"disabled,omitempty"`
-
 	// Inherits the base spec fields from the corresponding UserAccount
 	UserAccountSpecBase `json:",inline"`
 }

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -710,20 +710,6 @@ func schema_pkg_apis_toolchain_v1alpha1_UserAccountSpecEmbedded(ref common.Refer
 				Description: "UserAccountSpecEmbedded defines the desired state of UserAccount",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"userID": {
-						SchemaProps: spec.SchemaProps{
-							Description: "UserID is the user ID from RHD Identity Provider token (“sub” claim) Is to be used to create Identity and UserIdentityMapping resources. This field is duplicated and will be removed in the future.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"disabled": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If set to true then the corresponding user should not be able to login \"false\" is assumed by default. This field is duplicated and will be removed in the future.",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"nsLimit": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The namespace limit name",


### PR DESCRIPTION
## Description
Deprecating Embedded UserAccount ID and UserAccount Disabled fields.

Relates to Jira task: https://issues.redhat.com/browse/CRT-457
Relates to Jira story: https://issues.redhat.com/browse/CRT-444

This will be done in three stages:

1. Deprecate Embedded UA ID/Disabled
1.1 PRs:
https://github.com/codeready-toolchain/api/pull/100
https://github.com/codeready-toolchain/host-operator/pull/143
2. Change the implementation and start using the new API. Roll out to prod.
2.1 PRs: 
https://github.com/codeready-toolchain/host-operator/pull/146
https://github.com/codeready-toolchain/toolchain-e2e/pull/73
3. Delete deprecated API.
3.1 PRs: 
https://github.com/codeready-toolchain/host-operator/pull/147
https://github.com/codeready-toolchain/toolchain-common/pull/79

This PR is part of stage 3.

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes
2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/147
