### PR TITLE
Make cluster resources a pointer so it's easy to use it as optional field

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
@@ -19,7 +19,7 @@ type NSTemplateTierSpec struct {
 
 	// the cluster resources template (for cluster-wide quotas, etc.)
 	// +optional
-	ClusterResources NSTemplateTierClusterResources `json:"clusterResources,omitempty"`
+	ClusterResources *NSTemplateTierClusterResources `json:"clusterResources,omitempty"`
 }
 
 // NSTemplateTierNamespace the namespace definition in an NSTemplateTier resource

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
@@ -571,7 +571,11 @@ func (in *NSTemplateTierSpec) DeepCopyInto(out *NSTemplateTierSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.ClusterResources.DeepCopyInto(&out.ClusterResources)
+	if in.ClusterResources != nil {
+		in, out := &in.ClusterResources, &out.ClusterResources
+		*out = new(NSTemplateTierClusterResources)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
## Description
Required by https://github.com/codeready-toolchain/host-operator/pull/157

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
no