### PR TITLE
Moved constants from host operator

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -30,6 +30,12 @@ const (
 	UserSignupApprovedAutomaticallyReason          = "ApprovedAutomatically"
 	UserSignupApprovedByAdminReason                = "ApprovedByAdmin"
 	UserSignupPendingApprovalReason                = "PendingApproval"
+	UserSignupUserBanningReason                    = "Banning"
+	UserSignupUserBannedReason                     = "Banned"
+	UserSignupFailedToReadBannedUsersReason        = "FailedToReadBannedUsers"
+	UserSignupMissingUserEmailAnnotationReason     = "MissingUserEmailAnnotation"
+	UserSignupMissingEmailHashLabelReason          = "MissingEmailHashLabel"
+	UserSignupInvalidEmailHashLabelReason          = "InvalidEmailHashLabel"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
Move additional reason constants into api from host operator.  This change simply introduces new constant values, and doesn't change the structure of any resource definitions.
