### PR TITLE
add reason for cluster resource provisioning error

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -15,13 +15,14 @@ const (
 
 // These are valid status condition reasons of a NSTemplateSet
 const (
-	NSTemplateSetProvisionedReason                = provisionedReason
-	NSTemplateSetProvisioningReason               = provisioningReason
-	NSTemplateSetUnableToProvisionReason          = "UnableToProvision"
-	NSTemplateSetUnableToProvisionNamespaceReason = "UnableToProvisionNamespace"
-	NSTemplateSetTerminatingReason                = terminatingReason
-	NSTemplateSetUpdatingReason                   = updatingReason
-	NSTemplateSetUpdateFailedReason               = "UpdateFailed"
+	NSTemplateSetProvisionedReason                       = provisionedReason
+	NSTemplateSetProvisioningReason                      = provisioningReason
+	NSTemplateSetUnableToProvisionReason                 = "UnableToProvision"
+	NSTemplateSetUnableToProvisionNamespaceReason        = "UnableToProvisionNamespace"
+	NSTemplateSetUnableToProvisionClusterResourcesReason = "UnableToProvisionClusteResources"
+	NSTemplateSetTerminatingReason                       = terminatingReason
+	NSTemplateSetUpdatingReason                          = updatingReason
+	NSTemplateSetUpdateFailedReason                      = "UpdateFailed"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
## Description
Adding a new constant for the status/reason when the cluster resources provisioning failed on the member lcluster

## Checks
1. Have you run `make generate` target? **no**

Updates https://issues.redhat.com/browse/CRT-459

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
