### PR TITLE
Update operator-sdk to 0.16.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://codecov.io/gh/codeready-toolchain/api/branch/master/graph/badge.sv
 Requires:
 
 * Go version 1.13 - download for your development environment https://golang.org/dl/[here].
-* Operator-sdk version 0.15.2 - download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
+* Operator-sdk version 0.16.0 - download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
 
 CodeReady ToolChain API is built using https://github.com/golang/go/wiki/Modules[Go modules].  Set the following environment variable in your CLI before building:
 

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -55,7 +55,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # download, verify and install operator-sdk
 RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
     && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-    && gpg --keyserver keyserver.ubuntu.com --recv-key 9391EA2A \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 09FCE996 \
     && gpg --verify operator-sdk.asc \
     && chmod +x operator-sdk \
     && cp operator-sdk /usr/bin/operator-sdk \

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -9,7 +9,7 @@ ENV LANG=en_US.utf8 \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \
-    OPERATOR_SDK_VERSION=v0.15.2
+    OPERATOR_SDK_VERSION=v0.16.0
 
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/api
 


### PR DESCRIPTION
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/173
- member-operator: https://github.com/codeready-toolchain/member-operator/pull/140

~~When we merge this PR we will need to update the gpg key ID in Docker.tools file.~~