### PR TITLE
adding provider label

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -11,6 +11,7 @@ const (
 	RevisionLabelKey = LabelKeyPrefix + "revision"
 	TypeLabelKey     = LabelKeyPrefix + "type"
 	TierLabelKey     = LabelKeyPrefix + "tier"
+	ProviderLabelKey = LabelKeyPrefix + "provider"
 )
 
 // These are valid status condition reasons of a NSTemplateSet

--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	OwnerLabelKey    = LabelKeyPrefix + "owner"
-	RevisionLabelKey = LabelKeyPrefix + "revision"
-	TypeLabelKey     = LabelKeyPrefix + "type"
-	TierLabelKey     = LabelKeyPrefix + "tier"
-	ProviderLabelKey = LabelKeyPrefix + "provider"
+	OwnerLabelKey      = LabelKeyPrefix + "owner"
+	RevisionLabelKey   = LabelKeyPrefix + "revision"
+	TypeLabelKey       = LabelKeyPrefix + "type"
+	TierLabelKey       = LabelKeyPrefix + "tier"
+	ProviderLabelKey   = LabelKeyPrefix + "provider"
+	ProviderLabelValue = "codeready-toolchain"
 )
 
 // These are valid status condition reasons of a NSTemplateSet


### PR DESCRIPTION
## Description
Adding the provider label key in order to add the provider label key to labels in the nstemplateset_controller. They will be removed from basic, advanced and teams (https://github.com/codeready-toolchain/host-operator/blob/master/deploy/templates/nstemplatetiers/.... ) 

Jira story: https://issues.redhat.com/browse/CRT-495

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes
2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
no
