### PR TITLE
add reason for NSTemplateSet terminating error

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -23,6 +23,7 @@ const (
 	NSTemplateSetUnableToProvisionNamespaceReason        = "UnableToProvisionNamespace"
 	NSTemplateSetUnableToProvisionClusterResourcesReason = "UnableToProvisionClusteResources"
 	NSTemplateSetTerminatingReason                       = terminatingReason
+	NSTemplateSetTerminatingFailedReason                 = "UnableToTerminate"
 	NSTemplateSetUpdatingReason                          = updatingReason
 	NSTemplateSetUpdateFailedReason                      = "UpdateFailed"
 )


### PR DESCRIPTION
## Description
reason to use when the NSTemplateSet termination failed

Updates https://issues.redhat.com/browse/CRT-459

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

## Checks
1. Have you run `make generate` target? **yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **no** 

