### PR TITLE
adding fields for notification service

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -62,6 +62,15 @@ type UserSignupSpec struct {
 
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`
+
+	// The user's first name, obtained from the identity provider.
+	GivenName string `json:"givenName"`
+
+	// The user's last name, obtained from the identity provider.
+	FamilyName string `json:"familyName"`
+
+	// The user's company name, obtained from the identity provider.
+	Company string `json:"company"`
 }
 
 // UserSignupStatus defines the observed state of UserSignup

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -64,12 +64,15 @@ type UserSignupSpec struct {
 	Username string `json:"username"`
 
 	// The user's first name, obtained from the identity provider.
+	// +optional
 	GivenName string `json:"givenName"`
 
 	// The user's last name, obtained from the identity provider.
+	// +optional
 	FamilyName string `json:"familyName"`
 
 	// The user's company name, obtained from the identity provider.
+	// +optional
 	Company string `json:"company"`
 }
 
@@ -101,6 +104,9 @@ type UserSignupStatus struct {
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=`.spec.userID`,priority=1
 // +kubebuilder:printcolumn:name="Username",type="string",JSONPath=`.spec.username`
+// +kubebuilder:printcolumn:name="First Name",type="string",JSONPath=`.spec.givenName`,priority=1
+// +kubebuilder:printcolumn:name="Last Name",type="string",JSONPath=`.spec.familyName`,priority=1
+// +kubebuilder:printcolumn:name="Company",type="string",JSONPath=`.spec.company`,priority=1
 // +kubebuilder:printcolumn:name="TargetCluster",type="string",JSONPath=`.spec.targetCluster`,priority=1
 // +kubebuilder:printcolumn:name="Complete",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].reason`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -65,15 +65,15 @@ type UserSignupSpec struct {
 
 	// The user's first name, obtained from the identity provider.
 	// +optional
-	GivenName string `json:"givenName"`
+	GivenName string `json:"givenName,omitempty"`
 
 	// The user's last name, obtained from the identity provider.
 	// +optional
-	FamilyName string `json:"familyName"`
+	FamilyName string `json:"familyName,omitempty"`
 
 	// The user's company name, obtained from the identity provider.
 	// +optional
-	Company string `json:"company"`
+	Company string `json:"company,omitempty"`
 }
 
 // UserSignupStatus defines the observed state of UserSignup

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1021,7 +1021,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"username", "givenName", "familyName", "company"},
+				Required: []string{"username"},
 			},
 		},
 	}

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -999,8 +999,29 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"givenName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's first name, obtained from the identity provider.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"familyName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's last name, obtained from the identity provider.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"company": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's company name, obtained from the identity provider.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"username"},
+				Required: []string{"username", "givenName", "familyName", "company"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
In order to customize notification messages to users, we require additional user information which we should store in the UserSignup CRD when the user first registers. The fields we plan to extract and store for the purpose of the notification service messages include the user's first name, last name and company. 

Jira Task: https://issues.redhat.com/browse/CRT-518

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes
2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/182
