### PR TITLE
feat: add TierTemplateSpec.TierName field

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/tiertemplate_types.go
+++ b/pkg/apis/toolchain/v1alpha1/tiertemplate_types.go
@@ -9,6 +9,9 @@ import (
 // +k8s:openapi-gen=true
 type TierTemplateSpec struct {
 
+	// The tier of the template. For example: "basic", "advanced", or "team"
+	TierName string `json:"tierName"`
+
 	// The type of the template. For example: "code", "dev", "stage" or "cluster"
 	Type string `json:"type"`
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -927,6 +927,13 @@ func schema_pkg_apis_toolchain_v1alpha1_TierTemplateSpec(ref common.ReferenceCal
 				Description: "TierTemplateSpec defines the desired state of TierTemplate",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"tierName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The tier of the template. For example: \"basic\", \"advanced\", or \"team\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The type of the template. For example: \"code\", \"dev\", \"stage\" or \"cluster\"",
@@ -948,7 +955,7 @@ func schema_pkg_apis_toolchain_v1alpha1_TierTemplateSpec(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"type", "revision", "template"},
+				Required: []string{"tierName", "type", "revision", "template"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## Description
This field will be helpful to determine to which
specific tier this template is associated to.
This avoids having to parse the resource name.

## Checks
1. Have you run `make generate` target? **yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **yes** 

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/191


Updates https://issues.redhat.com/browse/CRT-500

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>