### PR TITLE
feat: register TierTemplate and TierTemplateList types

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/tiertemplate_types.go
+++ b/pkg/apis/toolchain/v1alpha1/tiertemplate_types.go
@@ -45,3 +45,7 @@ type TierTemplateList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TierTemplate `json:"items"`
 }
+
+func init() {
+	SchemeBuilder.Register(&TierTemplate{}, &TierTemplateList{})
+}


### PR DESCRIPTION
## Description
Add missing init func to register the new `TierTemplate` and `TierTemplateList` types in the toolchain/v1alpha1 scheme

## Checks
1. Have you run `make generate` target? **yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **no** 

Updates https://issues.redhat.com/browse/CRT-500

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
