### PR TITLE
chore: add tier name to MUR printcolumns

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -140,6 +140,7 @@ type Cluster struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.spec.userAccounts[].targetCluster`
+// +kubebuilder:printcolumn:name="Tier",type="string",JSONPath=`.spec.userAccounts[].spec.nsTemplateSet.tierName`
 // +kubebuilder:printcolumn:name="Banned",type="string",JSONPath=`.spec.banned`,priority=1
 // +kubebuilder:printcolumn:name="Disabled",type="string",JSONPath=`.spec.disabled`,priority=1
 // +kubebuilder:validation:XPreserveUnknownFields


### PR DESCRIPTION
## Description
Adds tier name to MUR printcolumns - it's very useful for managing MUR promotions

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/193
