### PR TITLE
feat(CRT-501): make legacy fields optional and new ones mandatory

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -7,12 +7,11 @@ import (
 )
 
 const (
-	OwnerLabelKey      = LabelKeyPrefix + "owner"
-	RevisionLabelKey   = LabelKeyPrefix + "revision"
-	TypeLabelKey       = LabelKeyPrefix + "type"
-	TierLabelKey       = LabelKeyPrefix + "tier"
-	ProviderLabelKey   = LabelKeyPrefix + "provider"
-	ProviderLabelValue = "codeready-toolchain"
+	OwnerLabelKey       = LabelKeyPrefix + "owner"
+	TypeLabelKey        = LabelKeyPrefix + "type"
+	TemplateRefLabelKey = LabelKeyPrefix + "templateref"
+	ProviderLabelKey    = LabelKeyPrefix + "provider"
+	ProviderLabelValue  = "codeready-toolchain"
 )
 
 // These are valid status condition reasons of a NSTemplateSet
@@ -50,34 +49,34 @@ type NSTemplateSetSpec struct {
 
 // NSTemplateSetNamespace the namespace definition in an NSTemplateSet resource
 type NSTemplateSetNamespace struct {
-	// The type of the namespace. For example: ide|cicd|stage|default
-	Type string `json:"type"`
+	//The type of the namespace. For example: ide|cicd|stage|default
+	// +optional
+	Type string `json:"type,omitempty"`
 
 	// The revision of the corresponding template
-	Revision string `json:"revision"`
+	// +optional
+	Revision string `json:"revision,omitempty"`
 
 	// Optional field. Used to specify a custom template
 	// +optional
 	Template string `json:"template,omitempty"`
 
 	// TemplateRef The name of the TierTemplate resource which exists in the host cluster and which contains the template to use
-	// +optional
-	TemplateRef string `json:"templateRef,omitempty"`
+	TemplateRef string `json:"templateRef"`
 }
 
 // NSTemplateSetClusterResources defines the cluster-scoped resources associated with a given user
 type NSTemplateSetClusterResources struct {
-
 	// The revision of the corresponding template
-	Revision string `json:"revision"`
+	// +optional
+	Revision string `json:"revision,omitempty"`
 
 	// Template contains an OpenShift Template to be used for provisioning of cluster-scoped resources
 	// +optional
 	Template string `json:"template,omitempty"`
 
 	// TemplateRef The name of the TierTemplate resource which exists in the host cluster and which contains the template to use
-	// +optional
-	TemplateRef string `json:"templateRef,omitempty"`
+	TemplateRef string `json:"templateRef"`
 }
 
 // NSTemplateSetStatus defines the observed state of NSTemplateSet

--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -10,6 +10,7 @@ const (
 	OwnerLabelKey       = LabelKeyPrefix + "owner"
 	TypeLabelKey        = LabelKeyPrefix + "type"
 	TemplateRefLabelKey = LabelKeyPrefix + "templateref"
+	TierLabelKey        = LabelKeyPrefix + "tier"
 	ProviderLabelKey    = LabelKeyPrefix + "provider"
 	ProviderLabelValue  = "codeready-toolchain"
 )


### PR DESCRIPTION
## Description
Since we are moving to the `templateRef` field this PR is making it mandatory and the other fields (type, revision) optional.
In addition, there is a new label `/templateref` introduced and the old ones `/tier` and `/revision` removed, since they were just duplication of the information contained in the `/templateref` and there was no usage of it

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/205
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#
