### PR TITLE
chore: move constant containing clusterresources type name to api

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/tiertemplate_types.go
+++ b/pkg/apis/toolchain/v1alpha1/tiertemplate_types.go
@@ -5,6 +5,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ClusterResourcesType contains a type name of the template containing cluster-scoped resources
+const ClusterResourcesTemplateType = "clusterresources"
+
 // TierTemplateSpec defines the desired state of TierTemplate
 // +k8s:openapi-gen=true
 type TierTemplateSpec struct {


### PR DESCRIPTION
## Description
Move constant containing type name of a template that contains cluster-scoped resources into api repo. In addition, I made the string lower case since the name of the resource shouldn't contain any capital letter anyway.

related PRs:
https://github.com/codeready-toolchain/host-operator/pull/210
https://github.com/codeready-toolchain/member-operator/pull/160