### PR TITLE
Delete notificationtemplate from CRD generation

### DIFF
--- a/make/generate.mk
+++ b/make/generate.mk
@@ -4,7 +4,7 @@ API_FULL_GROUPNAME=toolchain.dev.openshift.com
 API_VERSION:=v1alpha1
 
 # how to dispatch the CRD files per repository (space-separated lists)
-HOST_CLUSTER_CRDS:=masteruserrecord nstemplatetier usersignup registrationservice banneduser changetierrequest notification notificationtemplate tiertemplate
+HOST_CLUSTER_CRDS:=masteruserrecord nstemplatetier usersignup registrationservice banneduser changetierrequest notification tiertemplate
 MEMBER_CLUSTER_CRDS:=useraccount nstemplateset
 
 .PHONY: generate


### PR DESCRIPTION
We have deleted notificationtemplate CRD but it's still in `make generate`. This PR cleans it up.