### PR TITLE
Handle CRD names ending with s and add a note about api generation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,4 +21,5 @@ To re-generate the `zz_generated.deepcopy.go` and `zz_generated.openapi.go` file
 make generate
 ```
 
+IMPORTANT: the codeready-toolchain repositories should be checked out under your GOPATH in order for the generation to generate files in the correct directories. eg. For this repository: `$GOPATH/src/github.com/codeready-toolchain/api`
 NOTE: the `make generate` will generate the CRD files in the local `deploy/crds` directory and then dispatch the `.yaml` files in the `host-operator` and `member-operator` repositories, assuming they have been checked out and that *they are in a clean state*, meaning that they have no pending changes, besides previous versions of the CRD files.

--- a/make/generate.mk
+++ b/make/generate.mk
@@ -78,12 +78,14 @@ generate-crds: vendor prepare-host-operator prepare-member-operator generate-kub
     # When dispatching CRD files we delete two first lines of CRDs ("\n----\n") to make a single manifest file out of the original multiple manifest file
     # Also we remove the line with 'type: object' from validation.openAPIV3Schema.properties path because it's incompatible with kube 1.11 which is used by minishift
 	@for crd in $(HOST_CLUSTER_CRDS) ; do \
-		sed -e '1,2d' -e '/^      type: object/d' deploy/crds/$(API_FULL_GROUPNAME)_$${crd}s.yaml > ../host-operator/deploy/crds/$(API_GROUPNAME)_$(API_VERSION)_$${crd}_crd.yaml ; \
-		rm deploy/crds/$(API_FULL_GROUPNAME)_$${crd}s.yaml; \
+		crd_plural=$$(echo $${crd} | sed -e 's/s$$/se/')s; \
+		sed -e '1,2d' -e '/^      type: object/d' deploy/crds/$(API_FULL_GROUPNAME)_$${crd_plural}.yaml > ../host-operator/deploy/crds/$(API_GROUPNAME)_$(API_VERSION)_$${crd}_crd.yaml ; \
+		rm deploy/crds/$(API_FULL_GROUPNAME)_$${crd_plural}.yaml; \
 	done
 	@for crd in $(MEMBER_CLUSTER_CRDS) ; do \
-		sed -e '1,2d' -e '/^      type: object/d' deploy/crds/$(API_FULL_GROUPNAME)_$${crd}s.yaml > ../member-operator/deploy/crds/$(API_GROUPNAME)_$(API_VERSION)_$${crd}_crd.yaml ; \
-		rm deploy/crds/$(API_FULL_GROUPNAME)_$${crd}s.yaml; \
+		crd_plural=$$(echo $${crd} | sed -e 's/s$$/se/')s; \
+		sed -e '1,2d' -e '/^      type: object/d' deploy/crds/$(API_FULL_GROUPNAME)_$${crd_plural}.yaml > ../member-operator/deploy/crds/$(API_GROUPNAME)_$(API_VERSION)_$${crd}_crd.yaml ; \
+		rm deploy/crds/$(API_FULL_GROUPNAME)_$${crd_plural}.yaml; \
 	done
 ifneq ($(wildcard deploy/crds/*.yaml),)
 	@echo "ERROR: some CRD files were not dispatched: $(wildcard deploy/crds/*.yaml)"


### PR DESCRIPTION
## Description

This PR handles 2 things:

1. Add a note to ensure users are aware that the toolchain repositories should be checked out under your GOPATH in order for the api generation to work correctly.

2. Trying to add CRDs with names that end with a 's' character results in the generate target failing with the following error:

```
go mod vendor
re-generating the deepcopy go file...
go run /Users/rajiv/go/src/github.com/codeready-toolchain/api/vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go \
	--input-dirs ./pkg/apis/toolchain/v1alpha1/ -O zz_generated.deepcopy \
	--bounding-dirs github.com/codeready-toolchain/api/pkg/apis "toolchain:v1alpha1" \
	--go-header-file=make/go-header.txt
re-generating the openapi go file...
go run /Users/rajiv/go/src/github.com/codeready-toolchain/api/vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go \
	--input-dirs ./pkg/apis/toolchain/v1alpha1/ \
	--output-package github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1 \
	--output-file-base zz_generated.openapi \
	--go-header-file=make/go-header.txt
API rule violation: names_match,github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1,RegistrationServiceSpec,EnvironmentVariables
API rule violation: names_match,github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1,ToolchainStatusStatus,MemberStatus
Re-generating the KubeFed CRD...
go run /Users/rajiv/go/src/github.com/codeready-toolchain/api/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd:trivialVersions=true \
	paths=./vendor/sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/... output:crd:dir=deploy/crds/kubefed/row output:stdout
Generating bindata and dispatching it in the 'toolchain-common' repository...
Re-generating the Toolchain CRD files...
go run /Users/rajiv/go/src/github.com/codeready-toolchain/api/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd:trivialVersions=true \
	paths=./pkg/apis/... output:crd:dir=deploy/crds output:stdout
Dispatching CRD files in the 'host-operator' and 'member-operator' repositories...
sed: can't read deploy/crds/toolchain.dev.openshift.com_toolchainstatuss.yaml: No such file or directory
rm: deploy/crds/toolchain.dev.openshift.com_toolchainstatuss.yaml: No such file or directory
make: *** [generate-crds] Error 1
```

In this example generation produces CRD file `toolchain.dev.openshift.com_toolchainstatuses.yaml` instead of `toolchain.dev.openshift.com_toolchainstatuss.yaml`.

This change simply replaces 's' with 'ses' so that the generate target can correctly handle CRDs with names that end with 's'.

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
no

3. In case other projects are changed, please provides PR links.
    - None
