### PR TITLE
feat: support both versions of operator-sdk 0.16.0 and 0.17.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://codecov.io/gh/codeready-toolchain/api/branch/master/graph/badge.sv
 Requires:
 
 * Go version 1.13 - download for your development environment https://golang.org/dl/[here].
-* Operator-sdk version 0.16.0 - download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
+* Operator-sdk version 0.16.x or 0.17.x- download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
 
 CodeReady ToolChain API is built using https://github.com/golang/go/wiki/Modules[Go modules].  Set the following environment variable in your CLI before building:
 

--- a/make/generate.mk
+++ b/make/generate.mk
@@ -52,7 +52,7 @@ ifdef host_repo_status
 	@exit 1
 endif
 ifneq ($(wildcard ../host-operator/deploy/crds/*.yaml),)
-	@-find ../host-operator/deploy/crds -type f -not -name "*kubefed*" | xargs rm
+	@-find ../host-operator/deploy/crds -type f | grep -v "kubefed\|cr\.yaml" | xargs rm
 else
 	@-mkdir -p ../host-operator/deploy/crds
 endif
@@ -64,7 +64,7 @@ ifdef member_repo_status
 	@exit 1
 endif
 ifneq ($(wildcard ../member-operator/deploy/crds/*.yaml),)
-	@-find ../member-operator/deploy/crds -type f -not -name "*kubefed*" | xargs rm
+	@-find ../member-operator/deploy/crds -type f | grep -v "kubefed\|cr\.yaml" | xargs rm
 else
 	@-mkdir -p ../member-operator/deploy/crds
 endif

--- a/scripts/generate-deploy-hack.sh
+++ b/scripts/generate-deploy-hack.sh
@@ -89,7 +89,7 @@ metadata:
   namespace: openshift-marketplace
 data:
   customResourceDefinitions: |-
-$(for crd in `ls ${HACK_CRDS_DIR}/*.yaml | grep -v clusterserviceversion`; do cat ${crd} | indent_list; done)
+$(for crd in `ls ${HACK_CRDS_DIR}/*crd.yaml `; do cat ${crd} | indent_list; done)
   clusterServiceVersions: |-
 $(for csv in `find ${HACK_CSV_DIR} -name *clusterserviceversion.yaml`; do cat ${csv} | indent_list | sed -e 's|^ *$||g'; done)
   packages: |


### PR DESCRIPTION
## Description

The changes in this PR brings support of operator-sdk to our scripts. With these changes, we can use both versions of operator-sdk 0.16.0 and 0.17.1

This is very first step of supporting operator-sdk 0.17.1. After this, we will
1. migrate all repositories to use operator-sdk 0.17.1 in their dockerfiles
2. drop support of operator-sdk 0.16.0 in our scripts
3. adapt the structure of the repositories and the logic of our scripts to properly use operator-sdk 0.17.1
4. ... and some more steps that are still not clear right now :-) ... 