### PR TITLE
fix: use correct listType=atomic when needed or it makes sense

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -93,8 +93,7 @@ type MasterUserRecordStatus struct {
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// The status of user accounts in the member clusters which belong to this MasterUserRecord
-	// +listType=map
-	// +listMapKey=targetCluster
+	// +listType=atomic
 	UserAccounts []UserAccountStatusEmbedded `json:"userAccounts,omitempty"`
 }
 

--- a/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplateset_types.go
@@ -40,8 +40,7 @@ type NSTemplateSetSpec struct {
 	TierName string `json:"tierName"`
 
 	// The namespace templates
-	// +listType=map
-	// +listMapKey=type
+	// +listType=atomic
 	Namespaces []NSTemplateSetNamespace `json:"namespaces"`
 
 	// the cluster resources template (for cluster-wide quotas, etc.)

--- a/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
@@ -13,8 +13,7 @@ type NSTemplateTierSpec struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// The namespace templates
-	// +listType=map
-	// +listMapKey=type
+	// +listType=atomic
 	Namespaces []NSTemplateTierNamespace `json:"namespaces"`
 
 	// the cluster resources template (for cluster-wide quotas, etc.)

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -378,10 +378,7 @@ func schema_pkg_apis_toolchain_v1alpha1_MasterUserRecordStatus(ref common.Refere
 					"userAccounts": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"targetCluster",
-								},
-								"x-kubernetes-list-type": "map",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -465,10 +462,7 @@ func schema_pkg_apis_toolchain_v1alpha1_NSTemplateSetSpec(ref common.ReferenceCa
 					"namespaces": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"type",
-								},
-								"x-kubernetes-list-type": "map",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -590,10 +584,7 @@ func schema_pkg_apis_toolchain_v1alpha1_NSTemplateTierSpec(ref common.ReferenceC
 					"namespaces": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"type",
-								},
-								"x-kubernetes-list-type": "map",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
## Description
I changed the `listType` to `atomic` because:
* in MUR for `status.UserAccounts` because there is no field that would be used as a map key - the cluster is of the object type which cannot be used as a key.
* in both NSTemplateTier and NSTemplateSet because it makes more sense to have them as atomic since it more or less contains only the `templateRef` field

## Checks
1. Have you run `make generate` target? **[yes/no]**
**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/211 the commit https://github.com/codeready-toolchain/host-operator/pull/211/commits/b1f635b97ae53461aa21ecdf1860124158f9d9ab
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/163 the commit https://github.com/codeready-toolchain/member-operator/pull/163/commits/b7ae4cedbaffa78523604dd7f45441e880ff124f
