### PR TITLE
chore: drop opeator-sdk 0.16.x support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://codecov.io/gh/codeready-toolchain/api/branch/master/graph/badge.sv
 Requires:
 
 * Go version 1.13 - download for your development environment https://golang.org/dl/[here].
-* Operator-sdk version 0.16.x or 0.17.x- download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
+* Operator-sdk version 0.17.x- download and install https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md[here]
 
 CodeReady ToolChain API is built using https://github.com/golang/go/wiki/Modules[Go modules].  Set the following environment variable in your CLI before building:
 


### PR DESCRIPTION
## Description
Drops the support of operator-sdk 0.16.x and supports only 0.17.x
