### PR TITLE
chore: split push-to-quay-nightly.sh script into multiple scripts

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -47,9 +47,9 @@ fi
 
 GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short origin/master`
 # generate manifests
-check_main_and_embedded_repos_and_generate_manifests --channel alpha --template-version ${DEFAULT_VERSION} ${REPLACE_LAST_VERSION_PARAM}
+check_main_and_embedded_repos_and_generate_manifests --template-version ${DEFAULT_VERSION} ${REPLACE_LAST_VERSION_PARAM}
 
-copy_manifests_to_versioned_dir_and_adjust_package_file alpha
+copy_manifests_to_versioned_dir_and_adjust_package_file
 
 # delete the default bundle directory that is used as a template
 rm -rf ${BUNDLE_DIR}

--- a/scripts/generate-cd-release-manifests.sh
+++ b/scripts/generate-cd-release-manifests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+additional_help() {
+    echo "Important info: generate-release-manifest-for-cd.sh scripts overrides several parameters and expects/uses only some of the other ones - see below."
+    echo ""
+    echo "                The parameters written below are overridden with these values:"
+    echo "                      --template-version ${DEFAULT_VERSION}"
+    echo "                      --next-version 0.0.<number-of-commits>-<short-sha-of-latest-commit>"
+    echo "                      --replace-version 0.0.<number-of-commits-1>-<short-sha-of-last-but-one-commit>"
+    echo ""
+    echo "                Expected parameters to be passed (if needed):"
+    echo "                      --project-root"
+    echo "                      --embedded-repo"
+    echo "                      --quay-namespace"
+    echo "                      --operator-name"
+    echo ""
+    echo "                Variables overrides:"
+    echo "                      QUAY_NAMESPACE  - If this variables is set then you don't have to use the --quay-namespace parameter."
+    echo ""
+    echo "Example:"
+    echo "   ./scripts/generate-release-manifest-for-cd.sh -pr ../host-operator"
+    echo "          - This command will (re)generate CSV, CRDs in the manifests/ directory for the host-operator project"
+}
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/olm-setup.sh
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${OLM_SETUP_FILE})"
+    fi
+fi
+# read argument to get project root dir
+read_arguments $@
+
+# setup version variables based on commits so they can be used for generation process
+setup_version_variables_based_on_commits true
+
+# generate manifests
+check_main_and_embedded_repos_and_generate_manifests $@ --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}

--- a/scripts/olm-catalog-generate.sh
+++ b/scripts/olm-catalog-generate.sh
@@ -26,7 +26,6 @@ else
 fi
 
 read_arguments $@
-setup_variables
 generate_bundle
 generate_hack
 

--- a/scripts/push-manifests-as-app.sh
+++ b/scripts/push-manifests-as-app.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+additional_help() {
+    echo "Important info: push-manifests-as-app.sh scripts overrides several parameters and expects/uses only some of the other ones - see below."
+    echo ""
+    echo "                The parameters written below are overridden with these values:"
+    echo "                      --template-version ${DEFAULT_VERSION}"
+    echo "                      --next-version 0.0.<number-of-commits>-<short-sha-of-latest-commit>"
+    echo "                      --replace-version 0.0.<number-of-commits-1>-<short-sha-of-last-but-one-commit>"
+    echo ""
+    echo "                Expected parameters to be passed (if needed):"
+    echo "                      --project-root"
+    echo "                      --embedded-repo"
+    echo "                      --quay-namespace"
+    echo "                      --operator-name"
+    echo "                      --channel"
+    echo ""
+    echo "                Variables overrides:"
+    echo "                      QUAY_NAMESPACE  - If this variables is set then you don't have to use the --quay-namespace parameter."
+    echo ""
+    echo "                Optional variables:"
+    echo "                      QUAY_AUTH_TOKEN - Quay authentication token to be used for pushing to the quay namespace. If not set, then it's taken from ~/.docker/config.json file."
+    echo ""
+    echo "Example:"
+    echo "   ./scripts/push-to-quay-nightly.sh -pr ../host-operator"
+    echo "          - This command will copy manifests to versioned directory, modify the package file and push it all to quay namespace"
+    echo "            defined by either \"\${QUAY_NAMESPACE}\" variable or --quay-namespace parameter."
+}
+
+
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/olm-setup.sh
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${OLM_SETUP_FILE})"
+    fi
+fi
+
+# read arguments to get project root dir
+read_arguments $@
+
+# setup version variables based on commits so they can be used for pushing it to quay
+setup_version_variables_based_on_commits false
+
+# if the main repo is specified then reconfigure the variables so the project root points to the temp directory
+if [[ -n "${MAIN_REPO_URL}"  ]]; then
+    read_arguments $@ -pr ${OTHER_REPO_PATH}
+    setup_variables
+fi
+
+# copy manifestst to versioned directory and adjust the package file so it can be pushed to quay application
+copy_manifests_to_versioned_dir_and_adjust_package_file
+
+# push manifests to quay
+DIR_TO_PUSH=${PKG_DIR}
+push_manifests_as_app_to_quay

--- a/scripts/push-to-quay-manifest.sh
+++ b/scripts/push-to-quay-manifest.sh
@@ -32,8 +32,7 @@ NEXT_CSV_VERSION=`basename $(ls -d ${MANIFESTS_DIR}/*/ | sort | tail -1)`
 
 # read final arguments and setup vars
 read_arguments $@ --channel alpha --next-version ${NEXT_CSV_VERSION}
-setup_variables
 
 # push manifests to quay
 DIR_TO_PUSH=${MANIFESTS_DIR}
-push_to_quay
+push_manifests_as_app_to_quay

--- a/scripts/recover-operator-dir.sh
+++ b/scripts/recover-operator-dir.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+additional_help() {
+    echo "Important info: recover-operator-dir.sh scripts expects/uses only one parameter:"
+    echo "                      --project-root"
+    echo ""
+    echo "Example:"
+    echo "   ./scripts/recover-operator-dir.sh   -pr ../host-operator"
+    echo "          - This command will recover the operator bundle directory from the backup folder stored in /tmp/."
+}
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/olm-setup.sh
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/api/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${OLM_SETUP_FILE})"
+    fi
+fi
+
+# read argument to get project root dir
+read_arguments $@
+setup_variables
+
+# bring back the original operator package directory
+rm -rf ${PKG_DIR}
+cp -r ${PKG_DIR_BACKUP} ${PKG_DIR}


### PR DESCRIPTION
## Description
The main change in this PR is that the logic from the `push-to-quay-nightly.sh` script is split into multiple scripts so they can be called separately and with different parameters.
The new scripts are:
* `generate-cd-release-manifests.sh` - (re)generates the manifests files for the new release
* `push-manifests-as-app.sh` - creates the versioned directory and pushes the manifests into quay application
* `recover-operator-dir.sh` - recovers the operator bundle directory from the backup folder

Along with these changes I also modified a few more things:
* the channel is taken from the parameters so it's not hardcoded
* `setup_variables` function is read as part of the `read_arguments` so it doesn't have to be called separately
* moved `setup_version_variables_based_on_commits` function to `olm_setup.sh` scripts so it can be called from multiple places
* renamed `push_to_quay` to `push_manifests_as_app_to_quay`

And I know that I didn't change the README yet - it's more or less still relevant, but I'll rewrite it as soon as the scripts are done and in a final state.