### PR TITLE
feat: add ability to specify temp directory location

### DIFF
--- a/scripts/create-release-bundle.sh
+++ b/scripts/create-release-bundle.sh
@@ -68,4 +68,4 @@ cp -r ${PKG_DIR_BACKUP} ${PKG_DIR}
 operator-courier --verbose verify ${MANIFESTS_DIR}
 
 # Vars for deploy hack
-generate_deploy_hack -crds ${MANIFESTS_DIR}/${NEXT_CSV_VERSION} -csvs ${MANIFESTS_DIR}/ -pf ${MANIFESTS_DIR}/${OPERATOR_NAME}.package.yaml -hd /tmp/hack_deploy_${OPERATOR_NAME}_${NEXT_CSV_VERSION} -on ${OPERATOR_NAME}
+generate_deploy_hack -crds ${MANIFESTS_DIR}/${NEXT_CSV_VERSION} -csvs ${MANIFESTS_DIR}/ -pf ${MANIFESTS_DIR}/${OPERATOR_NAME}.package.yaml -hd ${TEMP_DIR}/hack_deploy_${OPERATOR_NAME}_${NEXT_CSV_VERSION} -on ${OPERATOR_NAME}

--- a/scripts/generate-deploy-hack.sh
+++ b/scripts/generate-deploy-hack.sh
@@ -16,8 +16,8 @@ user_help () {
     echo "-h,    --help            To show this help text"
     echo ""
     echo "Examples:"
-    echo "   ./scripts/generate-deploy-hack.sh -on codeready-toolchain-operator -csvs manifests/ -crds manifests/0.1.1/ -pf manifests/codeready-toolchain-operator.package.yaml -hd /tmp/crto-0.1.1"
-    echo "          - This command will generate deploy_csv.yaml file inside of /tmp/crto-0.1.1 directory."
+    echo "   ./scripts/generate-deploy-hack.sh -on codeready-toolchain-operator -csvs manifests/ -crds manifests/0.1.1/ -pf manifests/codeready-toolchain-operator.package.yaml -hd /<temp-dir>/crto-0.1.1"
+    echo "          - This command will generate deploy_csv.yaml file inside of /<temp-dir>/crto-0.1.1 directory."
     echo "             The deployment will contain all CSVs found in manifests/ directory recursively and all CRDs from manifests/0.1.1/ directory. "
     echo ""
     exit 0

--- a/scripts/olm-setup.sh
+++ b/scripts/olm-setup.sh
@@ -134,6 +134,9 @@ setup_variables() {
 
     # Temporal directory
     TEMP_DIR=${TEMP_DIR:-/tmp}
+    if [[ "${TEMP_DIR}" != "/tmp" ]]; then
+        mkdir -p ${TEMP_DIR} || true
+    fi
     OTHER_REPO_ROOT_DIR=${TEMP_DIR}/cd/other-repo
 
     # Files and directories related vars

--- a/scripts/recover-operator-dir.sh
+++ b/scripts/recover-operator-dir.sh
@@ -6,7 +6,7 @@ additional_help() {
     echo ""
     echo "Example:"
     echo "   ./scripts/recover-operator-dir.sh   -pr ../host-operator"
-    echo "          - This command will recover the operator bundle directory from the backup folder stored in /tmp/."
+    echo "          - This command will recover the operator bundle directory from the backup folder stored in /<temp-dir>/."
 }
 
 # use the olm-setup as the source


### PR DESCRIPTION
## Description
We will need to execute the particular steps of the release process in separated containers in the CD so we cannot use the `/tmp` directory for storing some intermediate files - in case we would need the file read in the next step. Thus, there is a new option allowing us to specify a temp directory location.
