### PR TITLE
add condition and SyncIndexes in TemplateUpdateRequest status

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
+++ b/pkg/apis/toolchain/v1alpha1/nstemplatetier_types.go
@@ -4,8 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // NSTemplateTierSpec defines the desired state of NSTemplateTier
 // +k8s:openapi-gen=true
 type NSTemplateTierSpec struct {

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -18,8 +18,8 @@ const (
 	TemplateUpdateRequestUpdatedReason = "Updated"
 	// TemplateUpdateRequestUpdatingReason when the MasterUserRecord is still being updated
 	TemplateUpdateRequestUpdatingReason = updatingReason
-	// TemplateUpdateRequestFailedReason when an error occurred while updating the MasterUserRecord
-	TemplateUpdateRequestFailedReason = "UnableToUpdate"
+	// TemplateUpdateRequestUnableToUpdateReason when an error occurred while updating the MasterUserRecord
+	TemplateUpdateRequestUnableToUpdateReason = "UnableToUpdate"
 )
 
 // TemplateUpdateRequestSpec defines the desired state of TemplateUpdateRequest

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -16,8 +16,8 @@ const (
 	// Status condition reasons
 	// TemplateUpdateRequestUpdatedReason when the MasterUserRecord was successfully updated
 	TemplateUpdateRequestUpdatedReason = "Updated"
-	// TemplateUpdateRequestUpdateInProgressReason when the MasterUserRecord is still being updated
-	TemplateUpdateRequestInProgressReason = updatingReason
+	// TemplateUpdateRequestUpdatingReason when the MasterUserRecord is still being updated
+	TemplateUpdateRequestUpdatingReason = updatingReason
 	// TemplateUpdateRequestFailedReason when an error occurred while updating the MasterUserRecord
 	TemplateUpdateRequestFailedReason = "UnableToUpdate"
 )

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -12,6 +12,14 @@ const (
 	// TemplateUpdateRequestComplete when the MasterUserRecord has been updated (via the TemplateUpdateRequest)
 	// (for the Template Update Request, "complete" makes more sense than the usual "ready" condition type)
 	TemplateUpdateRequestComplete ConditionType = "Complete"
+
+	// Status condition reasons
+	// TemplateUpdateRequestCompleteReason when the MasterUserRecord was successfully updated
+	TemplateUpdateRequestCompleteReason = "Updated"
+	// TemplateUpdateRequestUpdateInProgressReason when the MasterUserRecord is still being updated
+	TemplateUpdateRequestInProgressReason = updatingReason
+	// TemplateUpdateRequestFailedReason when an error occurred while updating the MasterUserRecord
+	TemplateUpdateRequestFailedReason = "UnableToUpdate"
 )
 
 // TemplateUpdateRequestSpec defines the desired state of TemplateUpdateRequest
@@ -34,22 +42,32 @@ type TemplateUpdateRequestSpec struct {
 // +k8s:openapi-gen=true
 type TemplateUpdateRequestStatus struct {
 	// Conditions is an array of current TemplateUpdateRequest conditions
-	// Supported condition types: ConditionReady
+	// Supported condition types: TemplateUpdateRequestComplete
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// SyncIndexes is a map of the sync indexes per cluster before the template refs
+	// were updates in the MasterUserRecord
+	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	SyncIndexes map[string]string `json:"syncIndexes,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // TemplateUpdateRequest is the Schema for the templateupdaterequests API
 // +k8s:openapi-gen=true
-// +kubebuilder:resource:path=templateupdaterequests,scope=Namespaced
-// +kubebuilder:validation:XPreserveUnknownFields
 // +kubebuilder:printcolumn:name="Tier",type="string",JSONPath=`.spec.tierName`
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].status`
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].reason`
+// +kubebuilder:resource:path=templateupdaterequests,scope=Namespaced
+// +kubebuilder:subresource:status
+// +kubebuilder:validation:XPreserveUnknownFields
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Template UpdateRequest"
 type TemplateUpdateRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -14,8 +14,8 @@ const (
 	TemplateUpdateRequestComplete ConditionType = "Complete"
 
 	// Status condition reasons
-	// TemplateUpdateRequestCompleteReason when the MasterUserRecord was successfully updated
-	TemplateUpdateRequestCompleteReason = "Updated"
+	// TemplateUpdateRequestUpdatedReason when the MasterUserRecord was successfully updated
+	TemplateUpdateRequestUpdatedReason = "Updated"
 	// TemplateUpdateRequestUpdateInProgressReason when the MasterUserRecord is still being updated
 	TemplateUpdateRequestInProgressReason = updatingReason
 	// TemplateUpdateRequestFailedReason when an error occurred while updating the MasterUserRecord

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -69,7 +69,7 @@ type TemplateUpdateRequestStatus struct {
 // +kubebuilder:resource:path=templateupdaterequests,scope=Namespaced
 // +kubebuilder:subresource:status
 // +kubebuilder:validation:XPreserveUnknownFields
-// +operator-sdk:gen-csv:customresourcedefinitions.displayName="Template UpdateRequest"
+// +operator-sdk:gen-csv:customresourcedefinitions.displayName="Template Update Request"
 type TemplateUpdateRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -50,13 +50,13 @@ type TemplateUpdateRequestStatus struct {
 	// +listMapKey=type
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// SyncIndexes is a map of the sync indexes per cluster before the template refs
-	// were updates in the MasterUserRecord
+	// SyncIndexes contains the `syncIndex` for each cluster in the MasterUserRecord.
+	// The values here are "captured" before the MasterUserRecord is updated, so we can
+	// track the update progress on the member clusters.
 	// +optional
-	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +mapType=atomic
-	SyncIndexes map[string]string `json:"syncIndexes,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	SyncIndexes map[string]string `json:"syncIndexes,omitempty" patchStrategy:"merge"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -55,6 +55,7 @@ type TemplateUpdateRequestStatus struct {
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
+	// +mapType=atomic
 	SyncIndexes map[string]string `json:"syncIndexes,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
@@ -1087,6 +1087,13 @@ func (in *TemplateUpdateRequestStatus) DeepCopyInto(out *TemplateUpdateRequestSt
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SyncIndexes != nil {
+		in, out := &in.SyncIndexes, &out.SyncIndexes
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1094,7 +1094,7 @@ func schema_pkg_apis_toolchain_v1alpha1_TemplateUpdateRequestStatus(ref common.R
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions is an array of current TemplateUpdateRequest conditions Supported condition types: TemplateUpdateRequestCompleted",
+							Description: "Conditions is an array of current TemplateUpdateRequest conditions Supported condition types: TemplateUpdateRequestComplete",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1108,12 +1108,11 @@ func schema_pkg_apis_toolchain_v1alpha1_TemplateUpdateRequestStatus(ref common.R
 					"syncIndexes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-patch-merge-key": "type",
-								"x-kubernetes-patch-strategy":  "merge",
+								"x-kubernetes-patch-strategy": "merge",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "SyncIndexes is a map of the sync indexes per cluster before the template refs were updates in the MasterUserRecord",
+							Description: "SyncIndexes contains the `syncIndex` for each cluster in the MasterUserRecord. The values here are \"captured\" before the MasterUserRecord is updated, so we can track the update progress on the member clusters.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1094,12 +1094,33 @@ func schema_pkg_apis_toolchain_v1alpha1_TemplateUpdateRequestStatus(ref common.R
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions is an array of current TemplateUpdateRequest conditions Supported condition types: ConditionReady",
+							Description: "Conditions is an array of current TemplateUpdateRequest conditions Supported condition types: TemplateUpdateRequestCompleted",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Ref: ref("github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1.Condition"),
+									},
+								},
+							},
+						},
+					},
+					"syncIndexes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "SyncIndexes is a map of the sync indexes per cluster before the template refs were updates in the MasterUserRecord",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},


### PR DESCRIPTION
## Description
add condition and reasons for the TemplateUpdateRequest
also, in TemplateUpdateRequest.Status, add a `SyncIndexes` field which
will contain the `MasterUserRecord.UserAccount[].SyncIndex` as they existed
when the MasterUserRecord template refs were updated.
The TemplateUpdateRequest controller will track the changes on the `MasterUserRecord`
until ALL sync indexes in the status changed, at which point, the MasterUserRecord update
will be considered as complete.

## Checks
1. Have you run `make generate` target? **yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **yes** 

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/230
    - toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/113


