### PR TITLE
Make LastUpdatedTime truly optional

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/conditions.go
+++ b/pkg/apis/toolchain/v1alpha1/conditions.go
@@ -40,5 +40,5 @@ type Condition struct {
 	Message string `json:"message,omitempty"`
 	// Last time the condition was updated
 	// +optional
-	LastUpdatedTime metav1.Time `json:"lastUpdatedTime,omitempty"`
+	LastUpdatedTime *metav1.Time `json:"lastUpdatedTime,omitempty"`
 }

--- a/pkg/apis/toolchain/v1alpha1/memberstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/memberstatus_types.go
@@ -6,6 +6,13 @@ import (
 	kubefed "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 )
 
+// These are valid status condition reasons of a MemberStatus
+const (
+	// Status condition reasons
+	MemberStatusAllComponentsReady = "AllComponentsReady"
+	MemberStatusComponentsNotReady = "ComponentsNotReady"
+)
+
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // MemberStatusSpec defines the desired state of MemberStatus

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
@@ -219,7 +219,10 @@ func (in *Cluster) DeepCopy() *Cluster {
 func (in *Condition) DeepCopyInto(out *Condition) {
 	*out = *in
 	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
-	in.LastUpdatedTime.DeepCopyInto(&out.LastUpdatedTime)
+	if in.LastUpdatedTime != nil {
+		in, out := &in.LastUpdatedTime, &out.LastUpdatedTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 


### PR DESCRIPTION
## Description
Makes `LastUpdatedTime` truly optional. The api will be able to handle when the value is nil. Also added some status reason constants needed for MemberStatus.

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/232
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/173
    - toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/114

