### PR TITLE
Add required reason constants for Notification Controller

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/notification_types.go
+++ b/pkg/apis/toolchain/v1alpha1/notification_types.go
@@ -17,7 +17,7 @@ const (
 	NotificationSentReason          = "Sent"
 	NotificationDeletionErrorReason = "UnableToDeleteNotification"
 	NotificationContextErrorReason  = "NotificationContextError"
-	NotificationDeliveryErrorReason = "NotificationDeliveryError"
+	NotificationDeliveryErrorReason = "DeliveryError"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/apis/toolchain/v1alpha1/notification_types.go
+++ b/pkg/apis/toolchain/v1alpha1/notification_types.go
@@ -16,6 +16,8 @@ const (
 	// Status condition reasons
 	NotificationSentReason          = "Sent"
 	NotificationDeletionErrorReason = "UnableToDeleteNotification"
+	NotificationContextErrorReason  = "NotificationContextError"
+	NotificationDeliveryErrorReason = "NotificationDeliveryError"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
## Description
This PR just adds a couple of new reason constants.

Fixes https://issues.redhat.com/browse/CRT-678

**NotificationContextError** is set when there is an error while attempting to create a new notification context.
**NotificationDeliveryError** is set when there is an error during delivery of a notification.

## Checks
1. Have you run `make generate` target? **[no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
  *Not applicable - this PR only adds new constants*