### PR TITLE
convert TemplateUpdateRequest status conditions to atomic list

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
+++ b/pkg/apis/toolchain/v1alpha1/templateupdaterequest_types.go
@@ -44,11 +44,8 @@ type TemplateUpdateRequestStatus struct {
 	// Conditions is an array of current TemplateUpdateRequest conditions
 	// Supported condition types: TemplateUpdateRequestComplete
 	// +optional
-	// +patchMergeKey=type
-	// +patchStrategy=merge
-	// +listType=map
-	// +listMapKey=type
-	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	// +listType=atomic
+	Conditions []Condition `json:"conditions,omitempty"`
 
 	// SyncIndexes contains the `syncIndex` for each cluster in the MasterUserRecord.
 	// The values here are "captured" before the MasterUserRecord is updated, so we can

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1245,12 +1245,7 @@ func schema_pkg_apis_toolchain_v1alpha1_TemplateUpdateRequestStatus(ref common.R
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"type",
-								},
-								"x-kubernetes-list-type":       "map",
-								"x-kubernetes-patch-merge-key": "type",
-								"x-kubernetes-patch-strategy":  "merge",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
## Description
Change the list type of `TemplateUpdateRequest.Status.Conditions` to `atomic` so there is no merging of the entries. This will allow for duplicate entries in the conditions, when multiple failures happened when trying to update a `MasterUserRecord`

## Checks
1. Have you run `make generate` target? **yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **yes** 

3. In case other projects are changed, please provides PR links.
    - https://github.com/codeready-toolchain/host-operator/pull/243

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
