### PR TITLE
Add ProvisionedTime to MUR status

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -96,6 +96,10 @@ type MasterUserRecordStatus struct {
 	// The status of user accounts in the member clusters which belong to this MasterUserRecord
 	// +listType=atomic
 	UserAccounts []UserAccountStatusEmbedded `json:"userAccounts,omitempty"`
+
+	// The timestamp when the user was provisioned
+	// +optional
+	ProvisionedTime *metav1.Time `json:"provisionedTime,omitempty"`
 }
 
 // UserAccountSpecEmbedded defines the desired state of UserAccount

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
@@ -524,6 +524,10 @@ func (in *MasterUserRecordStatus) DeepCopyInto(out *MasterUserRecordStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ProvisionedTime != nil {
+		in, out := &in.ProvisionedTime, &out.ProvisionedTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -557,11 +557,17 @@ func schema_pkg_apis_toolchain_v1alpha1_MasterUserRecordStatus(ref common.Refere
 							},
 						},
 					},
+					"provisionedTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The timestamp when the user was provisioned",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1.Condition", "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1.UserAccountStatusEmbedded"},
+			"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1.Condition", "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1.UserAccountStatusEmbedded", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 


### PR DESCRIPTION
## Description
Adds the new MUR.Status.ProvisionedTime field that will be used to track when a user is first successfully provisioned. It will be the start time used for automatic user deactivation.

Related Issue:
https://issues.redhat.com/browse/CRT-754

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
host-operator

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/261
    - toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/122
