### PR TITLE
Added VerificationRequired reason constant

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -48,6 +48,7 @@ const (
 	UserSignupMissingUserEmailAnnotationReason     = "MissingUserEmailAnnotation"
 	UserSignupMissingEmailHashLabelReason          = "MissingEmailHashLabel"
 	UserSignupInvalidEmailHashLabelReason          = "InvalidEmailHashLabel"
+	UserSignupVerificationRequiredReason           = "VerificationRequired"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description

This PR simply adds a new reason constant:

`UserSignupVerificationRequiredReason           = "VerificationRequired"`

## Checks
1. Have you run `make generate` target? **[no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[n/a]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: n/a
    - member-operator: n/a
    - toolchain-common: n/a
