### PR TITLE
Fixed typo in constant name

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -22,8 +22,8 @@ const (
 	UserSignupVerificationCounterAnnotationKey = LabelKeyPrefix + "verification-counter"
 	// UserVerificationAttemptsAnnotationKey is used for the usersignup verification attempts annotation key
 	UserVerificationAttemptsAnnotationKey = LabelKeyPrefix + "verification-attempts"
-	// UserVerficationExpiryAnnotationKey is used for the usersignup verification expiry annotation key
-	UserVerficationExpiryAnnotationKey = LabelKeyPrefix + "verification-expiry"
+	// UserVerificationExpiryAnnotationKey is used for the usersignup verification expiry annotation key
+	UserVerificationExpiryAnnotationKey = LabelKeyPrefix + "verification-expiry"
 
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
 	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
This PR fixes a simple typo in the `UserVerificationExpiryAnnotationKey` constant name.

## Checks
1. Have you run `make generate` target? **[n/a]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)