### PR TITLE
feat(script): introduce first release param and index per commit

### DIFF
--- a/scripts/generate-cd-release-manifests.sh
+++ b/scripts/generate-cd-release-manifests.sh
@@ -40,4 +40,8 @@ read_arguments $@
 setup_version_variables_based_on_commits true
 
 # generate manifests
-check_main_and_embedded_repos_and_generate_manifests $@ --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}
+if [[ "${FIRST_RELEASE}" == "true" ]]; then
+    check_main_and_embedded_repos_and_generate_manifests $@ --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION}
+else
+    check_main_and_embedded_repos_and_generate_manifests $@ --template-version ${DEFAULT_VERSION} --next-version ${NEXT_CSV_VERSION} --replace-version ${REPLACE_CSV_VERSION}
+fi


### PR DESCRIPTION
## Description
This PR introduces two new params and functionalities into the CD scripts:
* `--index-per-commit` - when set to true, then the CD script will generate & push a new index image per release/commit. That means that it won't use the `latest` tag but will generate a new one for every release - the tag will equal to the tag of the bundle image.
* `--first-relase` - when set to true, then the generation scripts will generate CSV without any replacement. That means that the release is supposed to be the first one. The bundle&index push script detects that there is no replacement and if the `--index-per-commit` is used as well, then it doesn't use the `--from-index` param when adding a new bundle to the index image.

