### PR TITLE
Add constants for deactivation notification conditions

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -11,6 +11,8 @@ const (
 	UserSignupApproved ConditionType = "Approved"
 	// UserSignupComplete means provisioning is complete
 	UserSignupComplete ConditionType = "Complete"
+	// UserSignupUserDeactivatedNotificationCreated means that the Notification CR was created so the user should be notified about their deactivated account
+	UserSignupUserDeactivatedNotificationCreated ConditionType = "UserDeactivatedNotificationCreated"
 
 	// UserSignupUserEmailAnnotationKey is used for the usersignup email annotations key
 	UserSignupUserEmailAnnotationKey = LabelKeyPrefix + "user-email"
@@ -40,25 +42,28 @@ const (
 	UserSignupApprovedLabelValueFalse = "false"
 
 	// Status condition reasons
-	UserSignupNoClusterAvailableReason             = "NoClusterAvailable"
-	UserSignupNoTemplateTierAvailableReason        = "NoTemplateTierAvailable"
-	UserSignupFailedToReadUserApprovalPolicyReason = "FailedToReadUserApprovalPolicy"
-	UserSignupUnableToCreateMURReason              = "UnableToCreateMUR"
-	UserSignupUnableToUpdateApprovedLabelReason    = "UnableToUpdateApprovedLabel"
-	UserSignupUnableToDeleteMURReason              = "UnableToDeleteMUR"
-	UserSignupUserDeactivatingReason               = "Deactivating"
-	UserSignupUserDeactivatedReason                = "Deactivated"
-	UserSignupInvalidMURStateReason                = "InvalidMURState"
-	UserSignupApprovedAutomaticallyReason          = "ApprovedAutomatically"
-	UserSignupApprovedByAdminReason                = "ApprovedByAdmin"
-	UserSignupPendingApprovalReason                = "PendingApproval"
-	UserSignupUserBanningReason                    = "Banning"
-	UserSignupUserBannedReason                     = "Banned"
-	UserSignupFailedToReadBannedUsersReason        = "FailedToReadBannedUsers"
-	UserSignupMissingUserEmailAnnotationReason     = "MissingUserEmailAnnotation"
-	UserSignupMissingEmailHashLabelReason          = "MissingEmailHashLabel"
-	UserSignupInvalidEmailHashLabelReason          = "InvalidEmailHashLabel"
-	UserSignupVerificationRequiredReason           = "VerificationRequired"
+	UserSignupNoClusterAvailableReason                      = "NoClusterAvailable"
+	UserSignupNoTemplateTierAvailableReason                 = "NoTemplateTierAvailable"
+	UserSignupFailedToReadUserApprovalPolicyReason          = "FailedToReadUserApprovalPolicy"
+	UserSignupUnableToCreateMURReason                       = "UnableToCreateMUR"
+	UserSignupUnableToUpdateApprovedLabelReason             = "UnableToUpdateApprovedLabel"
+	UserSignupUnableToDeleteMURReason                       = "UnableToDeleteMUR"
+	UserSignupUserDeactivatingReason                        = "Deactivating"
+	UserSignupUserDeactivatedReason                         = "Deactivated"
+	UserSignupInvalidMURStateReason                         = "InvalidMURState"
+	UserSignupApprovedAutomaticallyReason                   = "ApprovedAutomatically"
+	UserSignupApprovedByAdminReason                         = "ApprovedByAdmin"
+	UserSignupPendingApprovalReason                         = "PendingApproval"
+	UserSignupUserBanningReason                             = "Banning"
+	UserSignupUserBannedReason                              = "Banned"
+	UserSignupFailedToReadBannedUsersReason                 = "FailedToReadBannedUsers"
+	UserSignupMissingUserEmailAnnotationReason              = "MissingUserEmailAnnotation"
+	UserSignupMissingEmailHashLabelReason                   = "MissingEmailHashLabel"
+	UserSignupInvalidEmailHashLabelReason                   = "InvalidEmailHashLabel"
+	UserSignupVerificationRequiredReason                    = "VerificationRequired"
+	UserSignupDeactivatedNotificationCRCreatedReason        = "NotificationCRCreated"
+	UserSignupDeactivatedNotificationCRNotCreatedReason     = "NotificationCRNotCreated"
+	UserSignupDeactivatedNotificationCRCreationFailedReason = "NotificationCRCreationFailed"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -62,7 +62,7 @@ const (
 	UserSignupInvalidEmailHashLabelReason                   = "InvalidEmailHashLabel"
 	UserSignupVerificationRequiredReason                    = "VerificationRequired"
 	UserSignupDeactivatedNotificationCRCreatedReason        = "NotificationCRCreated"
-	UserSignupDeactivatedNotificationCRNotCreatedReason     = "NotificationCRNotCreated"
+	UserSignupDeactivatedNotificationUserIsActiveReason     = "UserIsActive"
 	UserSignupDeactivatedNotificationCRCreationFailedReason = "NotificationCRCreationFailed"
 )
 


### PR DESCRIPTION
## Description
Just adds some constants that will be used for the user deactivation status on UserSignup resources. It allows us to keep track of whether a notification regarding the deactivation was sent to the user already so that we prevent sending repeat emails.

Related PR: https://github.com/codeready-toolchain/host-operator/pull/289

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
no

3. In case other projects are changed, please provides PR links.
n/a