### PR TITLE
chore: drop zones and region from ToolchainCluster

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/toolchaincluster_types.go
+++ b/pkg/apis/toolchain/v1alpha1/toolchaincluster_types.go
@@ -70,13 +70,6 @@ type ToolchainClusterStatus struct {
 	// Conditions is an array of current cluster conditions.
 	// +listType=atomic
 	Conditions []ToolchainClusterCondition `json:"conditions"`
-	// Zones are the names of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'.
-	// +optional
-	// +listType=set
-	Zones []string `json:"zones,omitempty"`
-	// Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.
-	// +optional
-	Region *string `json:"region,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
@@ -1824,16 +1824,6 @@ func (in *ToolchainClusterStatus) DeepCopyInto(out *ToolchainClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Zones != nil {
-		in, out := &in.Zones, &out.Zones
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.Region != nil {
-		in, out := &in.Region, &out.Region
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2092,32 +2092,6 @@ func schema_pkg_apis_toolchain_v1alpha1_ToolchainClusterStatus(ref common.Refere
 							},
 						},
 					},
-					"zones": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
-							},
-						},
-						SchemaProps: spec.SchemaProps{
-							Description: "Zones are the names of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
-									},
-								},
-							},
-						},
-					},
-					"region": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 				},
 				Required: []string{"conditions"},
 			},


### PR DESCRIPTION
## Description
Drop zones and region from ToolchainCluster CR because:
* it doesn't bring any additional value
* requires additional cluster-scoped permission to access `Nodes`
* makes the stuff a bit simpler
* if we are interested in Node zones & region, we should put it into Member/ToolchainStatus CRs

## Checks
1. Have you run `make generate` target? **[yes/no]**

yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/303
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/210
