### PR TITLE
Add toolchain status unready notification condition

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
@@ -6,6 +6,10 @@ import (
 
 // These are valid status condition reasons for Toolchain status
 const (
+	// ToolchainStatusUnreadyNotificationCreated is used when a notification has been sent to an admin mailing list
+	// after the toolchain status has been in an "unready" condition for an extended period of time
+	ToolchainStatusUnreadyNotificationCreated ConditionType = "ToolchainStatusUnreadyNotificationCreated"
+
 	// overall status condition reasons
 	ToolchainStatusAllComponentsReadyReason = "AllComponentsReady"
 	ToolchainStatusComponentsNotReadyReason = "ComponentsNotReady"

--- a/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
@@ -10,6 +10,9 @@ const (
 	// after the toolchain status has been in an "unready" condition for an extended period of time
 	ToolchainStatusUnreadyNotificationCreated ConditionType = "ToolchainStatusUnreadyNotificationCreated"
 
+	// ToolchainStatusUnreadyNotificationCRCreationFailedReason is set when the controller fails to create an unready notification CR
+	ToolchainStatusUnreadyNotificationCRCreationFailedReason = "UnreadyNotificationCRCreationFailed"
+
 	// overall status condition reasons
 	ToolchainStatusAllComponentsReadyReason = "AllComponentsReady"
 	ToolchainStatusComponentsNotReadyReason = "ComponentsNotReady"


### PR DESCRIPTION
This minor PR introduces a new condition constant only, in support of https://issues.redhat.com/browse/CRT-829

## Description
Adds a new `ToolchainStatusUnreadyNotificationCreated` condition, used when a notification is sent to an admin mailing list to indicate the toolchain has been in an unready status for an extended period of time.

## Checks
1. Have you run `make generate` target? **[no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

