### PR TITLE
Added recipient to notification CRD spec

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/notification_types.go
+++ b/pkg/apis/toolchain/v1alpha1/notification_types.go
@@ -31,7 +31,10 @@ type NotificationSpec struct {
 	// UserID is the user ID from RHD Identity Provider token (“sub” claim).  The UserID is used by
 	// the notification service (i.e. the NotificationController) to lookup the UserSignup resource for the user,
 	// and extract from it the values required to generate the notification content and to deliver the notification
-	UserID string `json:"userID"`
+	UserID string `json:"userID,omitempty"`
+
+	// Recipient may be used as an alternative to UserID to specify an email address where the notification will be delivered.
+	Recipient string `json:"recipient,omitempty"`
 
 	// Template is the name of the NotificationTemplate resource that will be used to generate the notification
 	Template string `json:"template"`

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1293,6 +1293,13 @@ func schema_pkg_apis_toolchain_v1alpha1_NotificationSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"recipient": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Recipient may be used as an alternative to UserID to specify an email address where the notification will be delivered.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"template": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Template is the name of the NotificationTemplate resource that will be used to generate the notification",
@@ -1301,7 +1308,7 @@ func schema_pkg_apis_toolchain_v1alpha1_NotificationSpec(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"userID", "template"},
+				Required: []string{"template"},
 			},
 		},
 	}


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/CRT-829

## Description
This PR adds a new `recipient` property to the Notification CRD spec.

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/313

