### PR TITLE
CRT-829 added subject and content properties to notification

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/notification_types.go
+++ b/pkg/apis/toolchain/v1alpha1/notification_types.go
@@ -37,7 +37,15 @@ type NotificationSpec struct {
 	Recipient string `json:"recipient,omitempty"`
 
 	// Template is the name of the NotificationTemplate resource that will be used to generate the notification
-	Template string `json:"template"`
+	Template string `json:"template,omitempty"`
+
+	// Subject is used when no template value is specified, in cases where the complete notification subject is
+	// specified at notification creation time
+	Subject string `json:"subject,omitempty"`
+
+	// Content is used when no template value is specified, in cases where the complete notification content is
+	// specified at notification creation time
+	Content string `json:"content,omitempty"`
 }
 
 // NotificationStatus defines the observed state of Notification

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1307,8 +1307,21 @@ func schema_pkg_apis_toolchain_v1alpha1_NotificationSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"subject": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subject is used when no template value is specified, in cases where the complete notification subject is specified at notification creation time",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"content": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Content is used when no template value is specified, in cases where the complete notification content is specified at notification creation time",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"template"},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
Adds subject and notification optional properties to the Notification CRD.

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/317
