### PR TITLE
Che delete condition

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -6,6 +6,9 @@ import (
 
 // These are valid status condition reasons of a UserAccount
 const (
+	// UserAccountCheCleanup reflects whether the user's Che data has been cleaned up or not
+	UserAccountCheCleanup ConditionType = "CheCleanup"
+
 	// Status condition reasons
 	UserAccountUnableToCreateUserReason          = "UnableToCreateUser"
 	UserAccountUnableToCreateIdentityReason      = "UnableToCreateIdentity"
@@ -16,6 +19,7 @@ const (
 	UserAccountDisabledReason                    = disabledReason
 	UserAccountDisablingReason                   = "Disabling"
 	UserAccountTerminatingReason                 = terminatingReason
+	UserAccountDeletingCheDataReason             = "DeletingCheData"
 	UserAccountUpdatingReason                    = updatingReason
 	UserAccountNSTemplateSetUpdateFailedReason   = "NSTemplateSetUpdateFailed"
 )
@@ -66,6 +70,8 @@ type UserAccountStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	CheUserID string `json:"cheUserID"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -70,8 +70,6 @@ type UserAccountStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
-
-	CheUserID string `json:"cheUserID"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Description
Adds a condition type for the Che deletion condition used by the useraccount controller. This condition is used to store the Che user ID in the status until deletion completes. The deletion API requires the user ID as a parameter and will return an error until the user is successfully removed. In some cases the user could be reported as non-existent while the deletion is still in progress so the user ID will not be retrievable from the user API but the cached user ID can be used with the Che user deletion API on retries.

## Checks
1. Have you run `make generate` target? **yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **no** 


3. In case other projects are changed, please provides PR links.
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#
