### PR TITLE
Removes unused che condition type and reason

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/useraccount_types.go
+++ b/pkg/apis/toolchain/v1alpha1/useraccount_types.go
@@ -6,9 +6,6 @@ import (
 
 // These are valid status condition reasons of a UserAccount
 const (
-	// UserAccountCheCleanup reflects whether the user's Che data has been cleaned up or not
-	UserAccountCheCleanup ConditionType = "CheCleanup"
-
 	// Status condition reasons
 	UserAccountUnableToCreateUserReason          = "UnableToCreateUser"
 	UserAccountUnableToCreateIdentityReason      = "UnableToCreateIdentity"
@@ -19,7 +16,6 @@ const (
 	UserAccountDisabledReason                    = disabledReason
 	UserAccountDisablingReason                   = "Disabling"
 	UserAccountTerminatingReason                 = terminatingReason
-	UserAccountDeletingCheDataReason             = "DeletingCheData"
 	UserAccountUpdatingReason                    = updatingReason
 	UserAccountNSTemplateSetUpdateFailedReason   = "NSTemplateSetUpdateFailed"
 )


### PR DESCRIPTION
## Description
Removes the UserAccountCheCleanup  and UserAccountDeletingCheDataReason constants since they'll be removed by https://github.com/codeready-toolchain/member-operator/pull/228

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
no

3. In case other projects are changed, please provides PR links.
None