### PR TITLE
Use centos7 image from centos organization

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/centos:7 as build-tools
+FROM quay.io/centos/centos:7 as build-tools
 
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"


### PR DESCRIPTION
## Description
Use centos7 image from centos organization since the app-sre org's mirror isn't working anymore

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
no

3. In case other projects are changed, please provides PR links.
None