### PR TITLE
Added UserID property to UserSignup specification

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -44,7 +44,7 @@ const (
 
 	// MasterUserRecordOwnerLabelKey indicates the label value that contains the owner reference for this resource,
 	// which will be the UserSignup instance with the corresponding resource name
-	MasterUserRecordOwnerLabelKey = LabelKeyPrefix + "owner"
+	MasterUserRecordOwnerLabelKey = OwnerLabelKey
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -6,6 +6,9 @@ import (
 
 // These are valid conditions of a MasterUserRecord
 const (
+
+	// #### CONDITION TYPES ####
+
 	// MasterUserRecordProvisioning means the Master User Record is being provisioned
 	MasterUserRecordProvisioning ConditionType = "Provisioning"
 	// MasterUserRecordUserAccountNotReady means the User Account failed to be provisioned
@@ -14,6 +17,8 @@ const (
 	MasterUserRecordReady ConditionType = "Ready"
 	// MasterUserRecordUserProvisionedNotificationCreated means that the Notification CR was created so the user should be notified about the successful provisioning
 	MasterUserRecordUserProvisionedNotificationCreated ConditionType = "UserProvisionedNotificationCreated"
+
+	// #### CONDITION REASONS ####
 
 	// Status condition reasons
 	MasterUserRecordUnableToGetUserAccountReason             = "UnableToGetUserAccount"
@@ -30,7 +35,16 @@ const (
 	MasterUserRecordDisabledReason                           = disabledReason
 	MasterUserRecordNotificationCRCreatedReason              = "NotificationCRCreated"
 	MasterUserRecordNotificationCRCreationFailedReason       = "NotificationCRCreationFailed"
-	MasterUserRecordUserIDLabelKey                           = LabelKeyPrefix + "user-id"
+
+	// #### LABELS ####
+
+	// MasterUserRecordUserIDLabelKey
+	// Deprecated: This is to be replaced with MasterUserRecordOwnerLabelKey
+	MasterUserRecordUserIDLabelKey = LabelKeyPrefix + "user-id"
+
+	// MasterUserRecordOwnerLabelKey indicates the label value that contains the owner reference for this resource,
+	// which will be the UserSignup instance with the corresponding resource name
+	MasterUserRecordOwnerLabelKey = LabelKeyPrefix + "owner"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -101,7 +101,7 @@ type UserSignupSpec struct {
 
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
 	// +optional
-	UserID string `json:"userid"`
+	UserID string `json:"userid,omitempty"`
 
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -99,6 +99,9 @@ type UserSignupSpec struct {
 	// +optional
 	Deactivated bool `json:"deactivated,omitempty"`
 
+	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
+	UserID string `json:"userid"`
+
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`
 

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -100,6 +100,7 @@ type UserSignupSpec struct {
 	Deactivated bool `json:"deactivated,omitempty"`
 
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
+	// +optional
 	UserID string `json:"userid"`
 
 	// The user's username, obtained from the identity provider.

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2549,6 +2549,13 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"userid": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's user ID, obtained from the identity provider from the 'sub' (subject) claim",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"username": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The user's username, obtained from the identity provider.",
@@ -2585,7 +2592,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"username"},
+				Required: []string{"userid", "username"},
 			},
 		},
 	}

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2592,7 +2592,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"userid", "username"},
+				Required: []string{"username"},
 			},
 		},
 	}


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/CRT-915

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>

## Description
Adds a UserID property to UserSignup specification.  Adds a new label constant for `owner` label in MasterUserRecord.

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/359

