### PR TITLE
Remove deprecated user-id label constant

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
+++ b/pkg/apis/toolchain/v1alpha1/masteruserrecord_types.go
@@ -38,10 +38,6 @@ const (
 
 	// #### LABELS ####
 
-	// MasterUserRecordUserIDLabelKey
-	// Deprecated: This is to be replaced with MasterUserRecordOwnerLabelKey
-	MasterUserRecordUserIDLabelKey = LabelKeyPrefix + "user-id"
-
 	// MasterUserRecordOwnerLabelKey indicates the label value that contains the owner reference for this resource,
 	// which will be the UserSignup instance with the corresponding resource name
 	MasterUserRecordOwnerLabelKey = OwnerLabelKey


### PR DESCRIPTION
This PR is part of the cleanup step for https://issues.redhat.com/browse/CRT-915

## Description
This PR removes the deprecated `user-id` label constant.  Constant removal only, no structural changes made to resources

## Checks
1. Have you run `make generate` target? **[no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

