### PR TITLE
CRT-983 renamed Delivered display column to Sent

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/notification_types.go
+++ b/pkg/apis/toolchain/v1alpha1/notification_types.go
@@ -66,7 +66,7 @@ type NotificationStatus struct {
 
 	// Conditions is an array of current Notification conditions
 	// Supported condition types:
-	// Delivered
+	// Sent
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -82,7 +82,7 @@ type NotificationStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:printcolumn:name="User ID",type="string",JSONPath=`.spec.userID`,priority=1
-// +kubebuilder:printcolumn:name="Delivered",type="string",JSONPath=`.status.conditions[?(@.type=="Delivered")].status`
+// +kubebuilder:printcolumn:name="Sent",type="string",JSONPath=`.status.conditions[?(@.type=="Sent")].status`
 // +kubebuilder:validation:XPreserveUnknownFields
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Notification"
 type Notification struct {

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -1391,7 +1391,7 @@ func schema_pkg_apis_toolchain_v1alpha1_NotificationStatus(ref common.ReferenceC
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions is an array of current Notification conditions Supported condition types: Delivered",
+							Description: "Conditions is an array of current Notification conditions Supported condition types: Sent",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
Signed-off-by: sbryzak <sbryzak@gmail.com>

## Description
This PR renames the `Delivered` printcolumn to `Sent` in the Notification CRD.

Fixes https://issues.redhat.com/browse/CRT-983

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/386
