### PR TITLE
fix: use binary image param only for local execution

### DIFF
--- a/scripts/push-bundle-and-index-image.sh
+++ b/scripts/push-bundle-and-index-image.sh
@@ -185,10 +185,14 @@ if [[ -n ${INDEX_IMAGE_URL} ]]; then
     INDEX_IMAGE=${INDEX_IMAGE_URL}
 fi
 
+if [[ -z ${GITHUB_ACTIONS} ]]; then
+    BINARY_IMAGE_PARAM=--binary-image registry.redhat.io/openshift4/ose-operator-registry:v4.6
+fi
+
 if [[ -n ${FROM_INDEX_IMAGE} ]] && [[ `${IMAGE_BUILDER} pull ${FROM_INDEX_IMAGE}` ]]; then
-    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} --from-index ${FROM_INDEX_IMAGE} ${PULL_TOOL_PARAM} --binary-image registry.redhat.io/openshift4/ose-operator-registry:v4.6
+    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} --from-index ${FROM_INDEX_IMAGE} ${PULL_TOOL_PARAM} ${BINARY_IMAGE_PARAM}
 else
-    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} ${PULL_TOOL_PARAM} --binary-image registry.redhat.io/openshift4/ose-operator-registry:v4.6
+    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} ${PULL_TOOL_PARAM} ${BINARY_IMAGE_PARAM}
 fi
 
 if [[ ${IMAGE_BUILDER} == "buildah" ]]; then


### PR DESCRIPTION
in GH action it's not needed since it always uses the latest one