### PR TITLE
Added new property apiEndpoint in memberStatusStatus and updated used…

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/memberstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/memberstatus_types.go
@@ -21,6 +21,9 @@ type MemberStatusStatus struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
+	// ApiEndpoint is the server API URL of the cluster
+	// +optional
+	ApiEndpoint string `json:"apiEndpoint,omitempty"`
 	// Che is the status of Che/CRW, such as installed and whether the member configuration is correct
 	// +optional
 	Che *CheStatus `json:"che,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -100,7 +100,7 @@ type UserSignupSpec struct {
 	Deactivated bool `json:"deactivated,omitempty"`
 
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
-	UserID string `json:"userID"`
+	UserID string `json:"userid"`
 
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -100,7 +100,7 @@ type UserSignupSpec struct {
 	Deactivated bool `json:"deactivated,omitempty"`
 
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
-	UserID string `json:"userid"`
+	UserID string `json:"userID"`
 
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -932,6 +932,13 @@ func schema_pkg_apis_toolchain_v1alpha1_MemberStatusStatus(ref common.ReferenceC
 				Description: "MemberStatusStatus defines the observed state of the toolchain member status",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"apiEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ApiEndpoint is the server API URL of the cluster",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"che": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Che is the status of Che/CRW, such as installed and whether the member configuration is correct",
@@ -2549,7 +2556,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
-					"userid": {
+					"userID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The user's user ID, obtained from the identity provider from the 'sub' (subject) claim",
 							Type:        []string{"string"},
@@ -2592,7 +2599,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"userid", "username"},
+				Required: []string{"userID", "username"},
 			},
 		},
 	}

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2556,7 +2556,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
-					"userID": {
+					"userid": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The user's user ID, obtained from the identity provider from the 'sub' (subject) claim",
 							Type:        []string{"string"},
@@ -2599,7 +2599,7 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"userID", "username"},
+				Required: []string{"userid", "username"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
1. Added a new property - apiEndpoint - in MemberStatusStatus for fixes wrt : https://issues.redhat.com/browse/CRT-971
2. Updated json name 'userid' to 'userID' to avoid API rule violation.
## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/392
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/239
