### PR TITLE
Added new constants for user pre-deactivation notification

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/notification_types.go
+++ b/pkg/apis/toolchain/v1alpha1/notification_types.go
@@ -26,8 +26,9 @@ const (
 	NotificationTypeLabelKey = LabelKeyPrefix + "type"
 
 	// Notification Types which describe the type of notification being sent
-	NotificationTypeDeactivated = "deactivated"
-	NotificationTypeProvisioned = "provisioned"
+	NotificationTypeDeactivating = "deactivating"
+	NotificationTypeDeactivated  = "deactivated"
+	NotificationTypeProvisioned  = "provisioned"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -11,6 +11,9 @@ const (
 	UserSignupApproved ConditionType = "Approved"
 	// UserSignupComplete means provisioning is complete
 	UserSignupComplete ConditionType = "Complete"
+	// UserSignupUserDeactivatingNotificationCreated is used to track the status of the notification send to a user
+	// shortly before their account is due for deactivation
+	UserSignupUserDeactivatingNotificationCreated ConditionType = "UserDeactivatingNotificationCreated"
 	// UserSignupUserDeactivatedNotificationCreated means that the Notification CR was created so the user should be notified about their deactivated account
 	UserSignupUserDeactivatedNotificationCreated ConditionType = "UserDeactivatedNotificationCreated"
 
@@ -53,28 +56,55 @@ const (
 	UserSignupStateLabelValueBanned = "banned"
 
 	// Status condition reasons
-	UserSignupNoClusterAvailableReason                      = "NoClusterAvailable"
-	UserSignupNoTemplateTierAvailableReason                 = "NoTemplateTierAvailable"
-	UserSignupFailedToReadUserApprovalPolicyReason          = "FailedToReadUserApprovalPolicy"
-	UserSignupUnableToCreateMURReason                       = "UnableToCreateMUR"
-	UserSignupUnableToUpdateStateLabelReason                = "UnableToUpdateStateLabel"
-	UserSignupUnableToDeleteMURReason                       = "UnableToDeleteMUR"
-	UserSignupUserDeactivatingReason                        = "Deactivating"
-	UserSignupUserDeactivatedReason                         = "Deactivated"
-	UserSignupInvalidMURStateReason                         = "InvalidMURState"
-	UserSignupApprovedAutomaticallyReason                   = "ApprovedAutomatically"
-	UserSignupApprovedByAdminReason                         = "ApprovedByAdmin"
-	UserSignupPendingApprovalReason                         = "PendingApproval"
-	UserSignupUserBanningReason                             = "Banning"
-	UserSignupUserBannedReason                              = "Banned"
-	UserSignupFailedToReadBannedUsersReason                 = "FailedToReadBannedUsers"
-	UserSignupMissingUserEmailAnnotationReason              = "MissingUserEmailAnnotation"
-	UserSignupMissingEmailHashLabelReason                   = "MissingEmailHashLabel"
-	UserSignupInvalidEmailHashLabelReason                   = "InvalidEmailHashLabel"
-	UserSignupVerificationRequiredReason                    = "VerificationRequired"
-	UserSignupDeactivatedNotificationCRCreatedReason        = "NotificationCRCreated"
-	UserSignupDeactivatedNotificationUserIsActiveReason     = "UserIsActive"
-	UserSignupDeactivatedNotificationCRCreationFailedReason = "NotificationCRCreationFailed"
+	UserSignupNoClusterAvailableReason             = "NoClusterAvailable"
+	UserSignupNoTemplateTierAvailableReason        = "NoTemplateTierAvailable"
+	UserSignupFailedToReadUserApprovalPolicyReason = "FailedToReadUserApprovalPolicy"
+	UserSignupUnableToCreateMURReason              = "UnableToCreateMUR"
+	UserSignupUnableToUpdateStateLabelReason       = "UnableToUpdateStateLabel"
+	UserSignupUnableToDeleteMURReason              = "UnableToDeleteMUR"
+	UserSignupUserDeactivatingReason               = "Deactivating"
+	UserSignupUserDeactivatedReason                = "Deactivated"
+	UserSignupInvalidMURStateReason                = "InvalidMURState"
+	UserSignupApprovedAutomaticallyReason          = "ApprovedAutomatically"
+	UserSignupApprovedByAdminReason                = "ApprovedByAdmin"
+	UserSignupPendingApprovalReason                = "PendingApproval"
+	UserSignupUserBanningReason                    = "Banning"
+	UserSignupUserBannedReason                     = "Banned"
+	UserSignupFailedToReadBannedUsersReason        = "FailedToReadBannedUsers"
+	UserSignupMissingUserEmailAnnotationReason     = "MissingUserEmailAnnotation"
+	UserSignupMissingEmailHashLabelReason          = "MissingEmailHashLabel"
+	UserSignupInvalidEmailHashLabelReason          = "InvalidEmailHashLabel"
+	UserSignupVerificationRequiredReason           = "VerificationRequired"
+
+	notificationCRCreated        = "NotificationCRCreated"
+	userIsActive                 = "UserIsActive"
+	notificationCRCreationFailed = "NotificationCRCreationFailed"
+
+	// ###############################################################################
+	//    Deactivation Notification Status Reasons
+	// ###############################################################################
+
+	// UserSignupDeactivatedNotificationUserIsActiveReason is the value that the condition reason is set to when
+	// a previously deactivated user has been reactivated again (for example when a user signs up again after their
+	// sandbox has been deactivated)
+	UserSignupDeactivatedNotificationUserIsActiveReason = userIsActive
+
+	UserSignupDeactivatedNotificationCRCreatedReason = notificationCRCreated
+
+	UserSignupDeactivatedNotificationCRCreationFailedReason = notificationCRCreationFailed
+
+	// ###############################################################################
+	//    Pre-Deactivation Notification Status Reasons
+	// ###############################################################################
+
+	// UserSignupDeactivatingNotificationUserIsActiveReason is the value that the condition reason is set to when
+	// a previously deactivated user has been reactivated again (for example when a user signs up again after their
+	// sandbox has been deactivated)
+	UserSignupDeactivatingNotificationUserIsActiveReason = userIsActive
+
+	UserSignupDeactivatingNotificationCRCreatedReason = notificationCRCreated
+
+	UserSignupDeactivatingNotificationCRCreationFailedReason = notificationCRCreationFailed
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
## Description
This PR adds constants for a new "deactivating" UserSignup condition in order to manage the notifications sent to users prior to them becoming deactivated.  Only constants have been added, no structural changes to CRDs.

Fixes https://issues.redhat.com/browse/CRT-994

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
