### PR TITLE
moving ApiEndpoint from MemberStatus to Member

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/memberstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/memberstatus_types.go
@@ -21,9 +21,6 @@ type MemberStatusStatus struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	// ApiEndpoint is the server API URL of the cluster
-	// +optional
-	ApiEndpoint string `json:"apiEndpoint,omitempty"`
 	// Che is the status of Che/CRW, such as installed and whether the member configuration is correct
 	// +optional
 	Che *CheStatus `json:"che,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
@@ -178,6 +178,10 @@ type RegistrationServiceHealth struct {
 // Member contains the status of a member cluster
 // +k8s:openapi-gen=true
 type Member struct {
+	// ApiEndpoint is the server API URL of the cluster
+	// +optional
+	ApiEndpoint string `json:"apiEndpoint,omitempty"`
+
 	// The cluster identifier
 	ClusterName string `json:"clusterName"`
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -841,6 +841,13 @@ func schema_pkg_apis_toolchain_v1alpha1_Member(ref common.ReferenceCallback) com
 				Description: "Member contains the status of a member cluster",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"apiEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ApiEndpoint is the server API URL of the cluster",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The cluster identifier",
@@ -932,13 +939,6 @@ func schema_pkg_apis_toolchain_v1alpha1_MemberStatusStatus(ref common.ReferenceC
 				Description: "MemberStatusStatus defines the observed state of the toolchain member status",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"apiEndpoint": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ApiEndpoint is the server API URL of the cluster",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"che": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Che is the status of Che/CRW, such as installed and whether the member configuration is correct",


### PR DESCRIPTION
## Description
as per the conversation in https://github.com/codeready-toolchain/host-operator/pull/394, moving apiEndpoint from MemberStatus to Member wrt: https://issues.redhat.com/browse/CRT-971 

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/395
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/240
