### PR TITLE
Enforce states property type

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -105,7 +105,19 @@ const (
 	UserSignupDeactivatingNotificationCRCreatedReason = notificationCRCreated
 
 	UserSignupDeactivatingNotificationCRCreationFailedReason = notificationCRCreationFailed
+
+	// ###############################################################################
+	//    UserSignup States
+	// ###############################################################################
+
+	UserSignupStateApproved             = UserSignupState("approved")
+	UserSignupStateVerificationRequired = UserSignupState("verification-required")
+	UserSignupStateDeactivated          = UserSignupState("deactivated")
+	UserSignupStateDeactivating         = UserSignupState("deactivating")
+	UserSignupStateBanned               = UserSignupState("banned")
 )
+
+type UserSignupState string
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -159,7 +171,7 @@ type UserSignupSpec struct {
 
 	// States contains a number of values that reflect the desired state of the UserSignup.
 	// +optional
-	States []string `json:"states,omitempty"`
+	States []UserSignupState `json:"states,omitempty"`
 }
 
 // UserSignupStatus defines the observed state of UserSignup

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.deepcopy.go
@@ -2218,7 +2218,7 @@ func (in *UserSignupSpec) DeepCopyInto(out *UserSignupSpec) {
 	*out = *in
 	if in.States != nil {
 		in, out := &in.States, &out.States
-		*out = make([]string, len(*in))
+		*out = make([]UserSignupState, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
## Description
This PR introduces a new string property type called `UserSignupState`, used to enforce the type of values set for the `states` property.

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
