### PR TITLE
added restored notifcation condition reason

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
+++ b/pkg/apis/toolchain/v1alpha1/toolchainstatus_types.go
@@ -16,6 +16,9 @@ const (
 	// ToolchainStatusUnreadyNotificationCRCreationFailedReason is set when the controller fails to create an unready notification CR
 	ToolchainStatusUnreadyNotificationCRCreationFailedReason = "UnreadyNotificationCRCreationFailed"
 
+	// ToolchainStatusRestoredNotificationCRCreationFailedReason is set when the controller fails to create restored notification
+	ToolchainStatusRestoredNotificationCRCreationFailedReason = "RestoredNotificationCRCreationFailed"
+
 	// overall status condition reasons
 	ToolchainStatusAllComponentsReadyReason = "AllComponentsReady"
 	ToolchainStatusComponentsNotReadyReason = "ComponentsNotReady"


### PR DESCRIPTION
## Description
Added a Condition Reason of ToolchainStatus for RestoredNotificationCR creation fail
## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
