### PR TITLE
Modify reason constant for user in pre-deactivation phase

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -102,10 +102,10 @@ const (
 	//    Pre-Deactivation Notification Status Reasons
 	// ###############################################################################
 
-	// UserSignupDeactivatingNotificationUserIsActiveReason is the value that the condition reason is set to when
+	// UserSignupDeactivatingNotificationUserNotInPreDeactivationReason is the value that the condition reason is set to when
 	// a previously deactivated user has been reactivated again (for example when a user signs up again after their
-	// sandbox has been deactivated)
-	UserSignupDeactivatingNotificationUserIsActiveReason = userNotInPreDeactivation
+	// sandbox has been deactivated), and before a pre-deactivation notification has been sent.
+	UserSignupDeactivatingNotificationUserNotInPreDeactivationReason = userNotInPreDeactivation
 
 	UserSignupDeactivatingNotificationCRCreatedReason = notificationCRCreated
 

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -82,6 +82,7 @@ const (
 
 	notificationCRCreated        = "NotificationCRCreated"
 	userIsActive                 = "UserIsActive"
+	userNotInPreDeactivation     = "UserNotInPreDeactivation"
 	notificationCRCreationFailed = "NotificationCRCreationFailed"
 
 	// ###############################################################################
@@ -104,7 +105,7 @@ const (
 	// UserSignupDeactivatingNotificationUserIsActiveReason is the value that the condition reason is set to when
 	// a previously deactivated user has been reactivated again (for example when a user signs up again after their
 	// sandbox has been deactivated)
-	UserSignupDeactivatingNotificationUserIsActiveReason = userIsActive
+	UserSignupDeactivatingNotificationUserIsActiveReason = userNotInPreDeactivation
 
 	UserSignupDeactivatingNotificationCRCreatedReason = notificationCRCreated
 

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -103,8 +103,7 @@ const (
 	// ###############################################################################
 
 	// UserSignupDeactivatingNotificationUserNotInPreDeactivationReason is the value that the condition reason is set to
-	// when a new user signs up, or a previously deactivated user has been reactivated again (for example when a user
-	// signs up again after their sandbox has been deactivated), and before a pre-deactivation notification has been sent.
+	// for an active user, before entering the pre-deactivation period
 	UserSignupDeactivatingNotificationUserNotInPreDeactivationReason = userNotInPreDeactivation
 
 	UserSignupDeactivatingNotificationCRCreatedReason = notificationCRCreated

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -102,9 +102,9 @@ const (
 	//    Pre-Deactivation Notification Status Reasons
 	// ###############################################################################
 
-	// UserSignupDeactivatingNotificationUserNotInPreDeactivationReason is the value that the condition reason is set to when
-	// a previously deactivated user has been reactivated again (for example when a user signs up again after their
-	// sandbox has been deactivated), and before a pre-deactivation notification has been sent.
+	// UserSignupDeactivatingNotificationUserNotInPreDeactivationReason is the value that the condition reason is set to
+	// when a new user signs up, or a previously deactivated user has been reactivated again (for example when a user
+	// signs up again after their sandbox has been deactivated), and before a pre-deactivation notification has been sent.
 	UserSignupDeactivatingNotificationUserNotInPreDeactivationReason = userNotInPreDeactivation
 
 	UserSignupDeactivatingNotificationCRCreatedReason = notificationCRCreated


### PR DESCRIPTION
## Description
This PR modifies the existing "UserIsActive" reason to a more precise "UserNotInPreDeactivation" description.  Constant value changed only, no structural changes made.

## Checks
1. Have you run `make generate` target? **[no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[N/A]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

