### PR TITLE
Removed Deactivated property from Spec

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -209,7 +209,7 @@ type UserSignupStatus struct {
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].reason`
 // +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].status`,priority=1
 // +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].reason`,priority=1
-// +kubebuilder:printcolumn:name="Deactivated",type="string",JSONPath=`.spec.states[?(@=="deactivated")]`,priority=1
+// +kubebuilder:printcolumn:name="States",type="string",JSONPath=`.spec.states`,priority=1
 // +kubebuilder:printcolumn:name="CompliantUsername",type="string",JSONPath=`.status.compliantUsername`
 // +kubebuilder:printcolumn:name="Email",type="string",JSONPath=`.metadata.annotations.toolchain\.dev\.openshift\.com/user-email`
 // +kubebuilder:validation:XPreserveUnknownFields

--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -142,11 +142,6 @@ type UserSignupSpec struct {
 	// Deprecated: will be replaced by States
 	Approved bool `json:"approved,omitempty"`
 
-	// Deactivated is used to deactivate the user.  If not set, then by default the user is active
-	// +optional
-	// Deprecated: will be replaced by States
-	Deactivated bool `json:"deactivated,omitempty"`
-
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
 	UserID string `json:"userid"`
 
@@ -214,7 +209,7 @@ type UserSignupStatus struct {
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Complete")].reason`
 // +kubebuilder:printcolumn:name="Approved",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].status`,priority=1
 // +kubebuilder:printcolumn:name="ApprovedBy",type="string",JSONPath=`.status.conditions[?(@.type=="Approved")].reason`,priority=1
-// +kubebuilder:printcolumn:name="Deactivated",type="string",JSONPath=`.spec.deactivated`,priority=1
+// +kubebuilder:printcolumn:name="Deactivated",type="string",JSONPath=`.spec.states[?(@=="deactivated")]`,priority=1
 // +kubebuilder:printcolumn:name="CompliantUsername",type="string",JSONPath=`.status.compliantUsername`
 // +kubebuilder:printcolumn:name="Email",type="string",JSONPath=`.metadata.annotations.toolchain\.dev\.openshift\.com/user-email`
 // +kubebuilder:validation:XPreserveUnknownFields

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2583,13 +2583,6 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
-					"deactivated": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Deactivated is used to deactivate the user.  If not set, then by default the user is active Deprecated: will be replaced by States",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"userid": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The user's user ID, obtained from the identity provider from the 'sub' (subject) claim",


### PR DESCRIPTION
## Description
This PR removes the Deactivated property from UserSignup.Spec.  

Fixes https://issues.redhat.com/browse/CRT-1087

Replaces the `Deactivated` printcolumn with a generic `States` column that prints all states, e.g (scroll right):

```
NAME                                   USERNAME               FIRST NAME   LAST NAME   COMPANY   TARGETCLUSTER   COMPLETE   REASON   APPROVED   APPROVEDBY   STATES                       COMPLIANTUSERNAME   EMAIL
1a03ecac-7c0b-44fc-b66d-12dd7fb21c40   johnsmith@redhat.com                                      east-2a                                                                                                      johnsmith@redhat.com
1a03ecac-7c0b-44fc-b66d-12dd7fb21c41   johnsmith@redhat.com                                      east-2a                                                     ["approved","deactivated"]                       johnsmith@redhat.com
```

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/420
