### PR TITLE
Removed VerificationRequired property

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -160,14 +160,6 @@ type UserSignupSpec struct {
 	// +optional
 	Company string `json:"company,omitempty"`
 
-	// VerificationRequired is used to determine if a user requires phone verification.
-	// The user should not be provisioned if VerificationRequired is set to true.
-	// VerificationRequired is set to false when the user is ether exempt from phone verification or has already successfully passed the verification.
-	// Default value is false.
-	// +optional
-	// Deprecated: will be replaced by States
-	VerificationRequired bool `json:"verificationRequired,omitempty"`
-
 	// States contains a number of values that reflect the desired state of the UserSignup.
 	// +optional
 	States []UserSignupState `json:"states,omitempty"`

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2618,13 +2618,6 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
-					"verificationRequired": {
-						SchemaProps: spec.SchemaProps{
-							Description: "VerificationRequired is used to determine if a user requires phone verification. The user should not be provisioned if VerificationRequired is set to true. VerificationRequired is set to false when the user is ether exempt from phone verification or has already successfully passed the verification. Default value is false. Deprecated: will be replaced by States",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"states": {
 						SchemaProps: spec.SchemaProps{
 							Description: "States contains a number of values that reflect the desired state of the UserSignup.",


### PR DESCRIPTION
## Description
This PR removes the `UserSignup.Spec.VerificationRequired` property

Fixes https://issues.redhat.com/browse/CRT-1103

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/423