### PR TITLE
fix: rename UserID->Userid & add missing listType

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/usersignup_types.go
+++ b/pkg/apis/toolchain/v1alpha1/usersignup_types.go
@@ -143,7 +143,7 @@ type UserSignupSpec struct {
 	Approved bool `json:"approved,omitempty"`
 
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
-	UserID string `json:"userid"`
+	Userid string `json:"userid"`
 
 	// The user's username, obtained from the identity provider.
 	Username string `json:"username"`
@@ -162,6 +162,7 @@ type UserSignupSpec struct {
 
 	// States contains a number of values that reflect the desired state of the UserSignup.
 	// +optional
+	// +listType=atomic
 	States []UserSignupState `json:"states,omitempty"`
 }
 

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -2619,6 +2619,11 @@ func schema_pkg_apis_toolchain_v1alpha1_UserSignupSpec(ref common.ReferenceCallb
 						},
 					},
 					"states": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "States contains a number of values that reflect the desired state of the UserSignup.",
 							Type:        []string{"array"},


### PR DESCRIPTION
## Description
Renames `UserID` to Userid`
adds missing listType to states

## Checks
1. Have you run `make generate` target? **[yes/no]**

**yes**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

**yes**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/436
