### PR TITLE
Removed UserSignup.Spec.Approved property

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -120,11 +120,24 @@ const (
 	//    UserSignup States
 	// ###############################################################################
 
-	UserSignupStateApproved             = UserSignupState("approved")
+	// UserSignupStateApproved - If set then the user has been manually approved.  Otherwise, if not set then
+	// the user is subject of auto-approval (if enabled)
+	UserSignupStateApproved = UserSignupState("approved")
+
+	// UserSignupStateVerificationRequired - If set then the user must complete the phone verification process
 	UserSignupStateVerificationRequired = UserSignupState("verification-required")
-	UserSignupStateDeactivated          = UserSignupState("deactivated")
-	UserSignupStateDeactivating         = UserSignupState("deactivating")
-	UserSignupStateBanned               = UserSignupState("banned")
+
+	// UserSignupStateDeactivating - If this state is set, it indicates that the user has entered the "pre-deactivation"
+	// phase and their account will be deactivated shortly.  Setting this state triggers the sending of a notification
+	// to the user to warn them of their pending account deactivation.
+	UserSignupStateDeactivating = UserSignupState("deactivating")
+
+	// UserSignupStateDeactivated - If this state is set, it means the user has been deactivated and they may no
+	// longer use their account
+	UserSignupStateDeactivated = UserSignupState("deactivated")
+
+	// UserSignupStateBanned - If this state is set by an admin then the user's account will be banned.
+	UserSignupStateBanned = UserSignupState("banned")
 )
 
 type UserSignupState string
@@ -141,12 +154,6 @@ type UserSignupSpec struct {
 	// If not set then the target cluster will be picked automatically
 	// +optional
 	TargetCluster string `json:"targetCluster,omitempty"`
-
-	// If Approved set to 'true' then the user has been manually approved
-	// If not set then the user is subject of auto-approval (if enabled)
-	// +optional
-	// Deprecated: will be replaced by States
-	Approved bool `json:"approved,omitempty"`
 
 	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
 	Userid string `json:"userid"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -415,7 +415,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_HostOperatorStatus(ref common.R
 					},
 					"masterUserRecordCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Number of MasterUserRecords created within the host cluster",
+							Description: "Number of MasterUserRecords created within the host cluster DEPRECATED: use `ToolchainStatusStatus.Metrics` instead",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -2573,13 +2573,6 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupSpec(ref common.Refer
 						SchemaProps: spec.SchemaProps{
 							Description: "The cluster in which the user is provisioned in If not set then the target cluster will be picked automatically",
 							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"approved": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If Approved set to 'true' then the user has been manually approved If not set then the user is subject of auto-approval (if enabled) Deprecated: will be replaced by States",
-							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},


### PR DESCRIPTION
## Description
This PR removes the UserSignup.Spec.Approved property, which has been replaced by UserSignup.Spec.States

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/446
