### PR TITLE
chore: drop vendoring and get tools with go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build/_output
 # the 'config' (originally deploy) directory should not be committed: all generated CRD files should be dispatched in the 'host-operator' and 'member-operator' repositories
 config
 deploy
+
+/bin

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,7 @@ golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -1,11 +1,11 @@
 .PHONY: clean
 ## Clean
-clean: remove-vendor remove-config
+clean: remove-bin remove-config
 	$(Q)go clean ${X_FLAG} ./...
 
-.PHONY: remove-vendor
-remove-vendor:
-	$(Q)-rm -rf ${V_FLAG} ./vendor
+.PHONY: remove-bin
+remove-bin:
+	$(Q)rm -rf ./bin
 
 .PHONY: remove-config
 remove-config:

--- a/make/get-tool.mk
+++ b/make/get-tool.mk
@@ -1,0 +1,30 @@
+CONTROLLER_GEN_VERSION=v0.4.1
+OPENAPI_GEN_VERSION=61e04a5be9a6
+
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+controller-gen: ## Download controller-gen locally if necessary.
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,${CONTROLLER_GEN_VERSION})
+
+OPENAPI_GEN = $(shell pwd)/bin/openapi-gen
+openapi-gen: ## Download openapi-gen locally if necessary.
+	$(call go-get-tool,$(OPENAPI_GEN),k8s.io/kube-openapi/cmd/openapi-gen,${OPENAPI_GEN_VERSION})
+
+# go-get-tool will 'go get' any package $2 with version $3 and install it to $1.
+PROJECT_DIR := $(shell pwd)
+VERSIONS_FILE := $(PROJECT_DIR)/bin/version
+
+define go-get-tool
+@if [[ ! -f ${1} ]] || [[ ! -f ${VERSIONS_FILE} ]] || [[ -z $$(grep ${2} ${VERSIONS_FILE} | grep '${3}$$') ]]; then \
+	set -e ;\
+	TMP_DIR=$$(mktemp -d) ;\
+	cd $${TMP_DIR} ;\
+	go mod init tmp ;\
+	echo "Downloading ${2}" ;\
+	GOBIN=$(PROJECT_DIR)/bin go get ${2}@${3} ;\
+	touch ${VERSIONS_FILE} ;\
+	sed '\|${2}|d' ${VERSIONS_FILE} > $${TMP_DIR}/versions ;\
+	mv $${TMP_DIR}/versions ${VERSIONS_FILE} ;\
+	echo "${2} ${3}" >> ${VERSIONS_FILE} ;\
+	rm -rf $$TMP_DIR ;\
+fi
+endef

--- a/make/go.mk
+++ b/make/go.mk
@@ -9,10 +9,6 @@ GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
 .PHONY: build
 ## Build
-build: remove-vendor $(shell find . -path ./vendor -prune -o -name '*.go' -print)
+build:
 	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
 	    go build github.com/codeready-toolchain/api/api/v1alpha1/
-
-.PHONY: vendor
-vendor: 
-	$(Q)go mod vendor


### PR DESCRIPTION
## Description
I decided to drop vendoring in order to get the needed version of the "generate" tools and start using a smarter version of what is generated by operator-sdk. It gets the binaries via `go get` command and stores them in `/bin` directory together with a file that contains the used versions of the binaries - to make sure that the correct version is used.

The main reason for doing it is that we will need the `kubebuilder` binary also in host/member operator repositories and keeping the vendor folder is sometimes pretty annoying. So, the same approach will be used in host/member operator repos to get `kubebuilder` & `kustomize` binaries.

I know that we agreed on not installing binaries from repos in makefiles targets, but - to be honest - I don't see any difference between getting the binaries via vendor folder and getting them via `go get` command.

Anyway, I'm open to discussion. 

Surprisingly, there are also some changes in the generated CRDs:
https://github.com/codeready-toolchain/member-operator/pull/260
https://github.com/codeready-toolchain/host-operator/pull/452