### PR TITLE
fix: add missing omitempty json marker

### DIFF
--- a/api/v1alpha1/notification_types.go
+++ b/api/v1alpha1/notification_types.go
@@ -54,7 +54,7 @@ type NotificationSpec struct {
 	// Context is used to set a number of arbitrary values to be passed to the notification content text formatter,
 	// for inclusion in the body of the notification.
 	// +optional
-	Context map[string]string `json:"context"`
+	Context map[string]string `json:"context,omitempty"`
 
 	// Template is the name of the NotificationTemplate resource that will be used to generate the notification
 	Template string `json:"template,omitempty"`


### PR DESCRIPTION
## Description
Add missing `omitempty` json marker as the `Context` field is optional

## Checks
1. Have you run `make generate` target? **[yes/no]**

yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)

No
