### PR TITLE
Added OriginalSub property to UserSignup, MUR and UserAccount CRDs

### DIFF
--- a/api/v1alpha1/masteruserrecord_types.go
+++ b/api/v1alpha1/masteruserrecord_types.go
@@ -77,6 +77,10 @@ type MasterUserRecordSpec struct {
 	// +listType=map
 	// +listMapKey=targetCluster
 	UserAccounts []UserAccountEmbedded `json:"userAccounts,omitempty"`
+
+	// OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to
+	// a new IdP provider client, and contains the user's "original-sub" claim
+	OriginalSub string `json:"originalSub,omitempty"`
 }
 
 type UserAccountEmbedded struct {

--- a/api/v1alpha1/masteruserrecord_types.go
+++ b/api/v1alpha1/masteruserrecord_types.go
@@ -80,6 +80,7 @@ type MasterUserRecordSpec struct {
 
 	// OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to
 	// a new IdP provider client, and contains the user's "original-sub" claim
+	// +optional
 	OriginalSub string `json:"originalSub,omitempty"`
 }
 

--- a/api/v1alpha1/useraccount_types.go
+++ b/api/v1alpha1/useraccount_types.go
@@ -18,10 +18,6 @@ const (
 	UserAccountTerminatingReason                 = terminatingReason
 	UserAccountUpdatingReason                    = updatingReason
 	UserAccountNSTemplateSetUpdateFailedReason   = "NSTemplateSetUpdateFailed"
-
-	// UserAccountOriginalSubAnnotationKey is used to set a temporary annotation value in order to migrate users
-	// to an SSO provider with the user's original UserID value as the sub claim
-	UserAccountOriginalSubAnnotationKey = UserSignupOriginalSubAnnotationKey
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -43,6 +39,10 @@ type UserAccountSpec struct {
 
 	// UserAccountBase contains all base spec fields
 	UserAccountSpecBase `json:",inline"`
+
+	// OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to
+	// a new IdP provider client, and contains the user's "original-sub" claim
+	OriginalSub string `json:"originalSub,omitempty"`
 }
 
 // UserAccountSpecBase defines the common fields between UserAccountSpec

--- a/api/v1alpha1/useraccount_types.go
+++ b/api/v1alpha1/useraccount_types.go
@@ -18,6 +18,10 @@ const (
 	UserAccountTerminatingReason                 = terminatingReason
 	UserAccountUpdatingReason                    = updatingReason
 	UserAccountNSTemplateSetUpdateFailedReason   = "NSTemplateSetUpdateFailed"
+
+	// UserAccountOriginalSubAnnotationKey is used to set a temporary annotation value in order to migrate users
+	// to an SSO provider with the user's original UserID value as the sub claim
+	UserAccountOriginalSubAnnotationKey = LabelKeyPrefix + "original-sub"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/api/v1alpha1/useraccount_types.go
+++ b/api/v1alpha1/useraccount_types.go
@@ -42,6 +42,7 @@ type UserAccountSpec struct {
 
 	// OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to
 	// a new IdP provider client, and contains the user's "original-sub" claim
+	// +optional
 	OriginalSub string `json:"originalSub,omitempty"`
 }
 

--- a/api/v1alpha1/useraccount_types.go
+++ b/api/v1alpha1/useraccount_types.go
@@ -21,7 +21,7 @@ const (
 
 	// UserAccountOriginalSubAnnotationKey is used to set a temporary annotation value in order to migrate users
 	// to an SSO provider with the user's original UserID value as the sub claim
-	UserAccountOriginalSubAnnotationKey = LabelKeyPrefix + "original-sub"
+	UserAccountOriginalSubAnnotationKey = UserSignupOriginalSubAnnotationKey
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -36,6 +36,10 @@ const (
 	// Activations are counted after phone verification succeeded
 	UserSignupActivationCounterAnnotationKey = LabelKeyPrefix + "activation-counter"
 
+	// UserSignupOriginalSubAnnotationKey is used to set a temporary annotation value in order to migrate users
+	// to an SSO provider with the user's original UserID value as the sub claim
+	UserSignupOriginalSubAnnotationKey = LabelKeyPrefix + "original-sub"
+
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
 	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"
 	// UserSignupUserPhoneHashLabelKey is used for the usersignup phone hash label key

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -36,10 +36,6 @@ const (
 	// Activations are counted after phone verification succeeded
 	UserSignupActivationCounterAnnotationKey = LabelKeyPrefix + "activation-counter"
 
-	// UserSignupOriginalSubAnnotationKey is used to set a temporary annotation value in order to migrate users
-	// to an SSO provider with the user's original UserID value as the sub claim
-	UserSignupOriginalSubAnnotationKey = LabelKeyPrefix + "original-sub"
-
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
 	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"
 	// UserSignupUserPhoneHashLabelKey is used for the usersignup phone hash label key
@@ -181,6 +177,10 @@ type UserSignupSpec struct {
 	// +optional
 	// +listType=atomic
 	States []UserSignupState `json:"states,omitempty"`
+
+	// OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to
+	// a new IdP provider client, and contains the user's "original-sub" claim
+	OriginalSub string `json:"originalSub,omitempty"`
 }
 
 // UserSignupStatus defines the observed state of UserSignup

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -180,6 +180,7 @@ type UserSignupSpec struct {
 
 	// OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to
 	// a new IdP provider client, and contains the user's "original-sub" claim
+	// +optional
 	OriginalSub string `json:"originalSub,omitempty"`
 }
 

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1032,6 +1032,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_MasterUserRecordSpec(ref common
 							},
 						},
 					},
+					"originalSub": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to a new IdP provider client, and contains the user's \"original-sub\" claim",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"userID"},
 			},
@@ -3381,6 +3388,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserAccountSpec(ref common.Refe
 							Ref:         ref("github.com/codeready-toolchain/api/api/v1alpha1.NSTemplateSetSpec"),
 						},
 					},
+					"originalSub": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to a new IdP provider client, and contains the user's \"original-sub\" claim",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"userID", "nsLimit", "nsTemplateSet"},
 			},
@@ -3607,6 +3621,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupSpec(ref common.Refer
 									},
 								},
 							},
+						},
+					},
+					"originalSub": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OriginalSub is an optional property temporarily introduced for the purpose of migrating the users to a new IdP provider client, and contains the user's \"original-sub\" claim",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},


### PR DESCRIPTION
## Description
This PR adds a new optional property `OriginalSub` to the following CRD resources:

- UserSignup
- MasterUserRecord
- UserAccount

This will be a temporary property used for the purposes of migrating users to a new IdP client.

Fixes https://issues.redhat.com/browse/CRT-1254

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)


Host Operator PR: https://github.com/codeready-toolchain/host-operator/pull/518
Member Operator PR: https://github.com/codeready-toolchain/member-operator/pull/300