### PR TITLE
Add an annotation to track the last target cluster

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -17,6 +17,8 @@ const (
 	// UserSignupUserDeactivatedNotificationCreated means that the Notification CR was created so the user should be notified about their deactivated account
 	UserSignupUserDeactivatedNotificationCreated ConditionType = "UserDeactivatedNotificationCreated"
 
+	// UserSignupLastTargetClusterAnnotationKey is used for tracking the cluster for returning users
+	UserSignupLastTargetClusterAnnotationKey = LabelKeyPrefix + "last-target-cluster"
 	// UserSignupUserEmailAnnotationKey is used for the usersignup email annotations key
 	UserSignupUserEmailAnnotationKey = LabelKeyPrefix + "user-email"
 	// UserSignupVerificationCodeAnnotationKey is used for the usersignup verification code annotation key


### PR DESCRIPTION
## Description
Adds an annotation that will be used to track the last target cluster for a UserSignup. It will be used to ensure returning users can be provisioned to the same target cluster they were previously provisioned to.

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
no

3. In case other projects are changed, please provides PR links.
n/a
