### PR TITLE
Status condition reason for last cluster annotation

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -66,6 +66,7 @@ const (
 	UserSignupNoTemplateTierAvailableReason        = "NoTemplateTierAvailable"
 	UserSignupFailedToReadUserApprovalPolicyReason = "FailedToReadUserApprovalPolicy"
 	UserSignupUnableToCreateMURReason              = "UnableToCreateMUR"
+	UserSignupUnableToUpdateAnnotationReason       = "UnableToUpdateAnnotation"
 	UserSignupUnableToUpdateStateLabelReason       = "UnableToUpdateStateLabel"
 	UserSignupUnableToDeleteMURReason              = "UnableToDeleteMUR"
 


### PR DESCRIPTION
## Description
Add a UserSignupUnableToUpdateAnnotationReason 

## Checks
1. Have you run `make generate` target? **[yes/no]**
yes

2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
no

3. In case other projects are changed, please provides PR links.
n/a
