### PR TITLE
chore: remove toolchain-common repo from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,8 @@ A few sentences describing the overall goals of the pull request's commits.
 ## Checks
 1. Have you run `make generate` target? **[yes/no]**
 
-2. Does `make generate` change anything in other projects (host-operator, member-operator, toolchain-common)? **[yes/no]** 
-(NOTE: You can ignore it if the only changes are in the annotation `alm-examples` of the `ClusterServiceVersion` object)
+2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]**
 
 3. In case other projects are changed, please provides PR links.
     - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#
     - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#
-    - toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/#


### PR DESCRIPTION
## Description
Updates the PR template so it looks like this:

## Checks
1. Have you run `make generate` target? **[yes/no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#

