### PR TITLE
Added constants for ToolchainEvent state label

### DIFF
--- a/api/v1alpha1/toolchainevent_types.go
+++ b/api/v1alpha1/toolchainevent_types.go
@@ -8,6 +8,17 @@ const (
 
 	// Status condition reasons
 	ToolchainEventInvalidTierReason = "InvalidTier"
+
+	ToolchainEventStateLabelKey = LabelKeyPrefix + "state"
+	// ToolchainEventStateLabelValueInactive is used for identifying that the ToolchainEvent is not yet ready for user activations
+	ToolchainEventStateLabelValueInactive = "inactive"
+
+	// ToolchainEventStateLabelValueActive is used to indicate that the ToolchainEvent is now active
+	ToolchainEventStateLabelValueActive = "active"
+
+	// ToolchainEventStateLabelValueExpired is used to indicate that the event has concluded and users may no longer
+	// sign up using its activation code
+	ToolchainEventStateLabelValueExpired = "expired"
 )
 
 // ToolchainEventSpec defines the parameters for a Toolchain event, such as a training session or workshop. Users


### PR DESCRIPTION
## Description
This PR adds constants used to manage the ToolchainEvent's state label.  No regeneration necessary, as PR only contains new constant definitions and nothing else.

## Checks
1. Have you run `make generate` target? **[no]**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[no]**

