### PR TITLE
Removed ActivationCode from Spec, added constant for activation-code label

### DIFF
--- a/api/v1alpha1/toolchainevent_types.go
+++ b/api/v1alpha1/toolchainevent_types.go
@@ -8,6 +8,8 @@ const (
 
 	// Status condition reasons
 	ToolchainEventInvalidTierReason = "InvalidTier"
+
+	ToolchainEventActivationCodeLabelKey = LabelKeyPrefix + "activation-code"
 )
 
 // ToolchainEventSpec defines the parameters for a Toolchain event, such as a training session or workshop. Users
@@ -34,9 +36,6 @@ type ToolchainEventSpec struct {
 	// The tier to assign to users registering for the event.  This must be the valid name of an nstemplatetier resource.
 	// +optional
 	Tier string `json:"tier,omitempty"`
-
-	// The unique activation code for the event
-	ActivationCode string `json:"activationCode"`
 
 	// If true, best effort is made to provision all attendees of the event on the same cluster
 	// +optional

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -3194,14 +3194,6 @@ func schema_codeready_toolchain_api_api_v1alpha1_ToolchainEventSpec(ref common.R
 							Format:      "",
 						},
 					},
-					"activationCode": {
-						SchemaProps: spec.SchemaProps{
-							Description: "The unique activation code for the event",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"preferSameCluster": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If true, best effort is made to provision all attendees of the event on the same cluster",
@@ -3217,7 +3209,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_ToolchainEventSpec(ref common.R
 						},
 					},
 				},
-				Required: []string{"startTime", "endTime", "maxAttendees", "activationCode"},
+				Required: []string{"startTime", "endTime", "maxAttendees"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## Description
This PR removes the `ActivationCode` property from `ToolchainEvent.Spec`, and instead introduces a new label constant so that the activation code can instead be stored as a label value.  This will enable easier lookup of the `ToolchainEvent` resource.

## Checks
1. Have you run `make generate` target? **[yes]**

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes]**

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/538
