### PR TITLE
Default space tier

### DIFF
--- a/api/v1alpha1/toolchainconfig_types.go
+++ b/api/v1alpha1/toolchainconfig_types.go
@@ -372,6 +372,10 @@ type TiersConfig struct {
 	// +optional
 	DefaultTier *string `json:"defaultTier,omitempty"`
 
+	// DefaultSpaceTier specifies the default tier to assign for new spaces
+	// +optional
+	DefaultSpaceTier *string `json:"defaultSpaceTier,omitempty"`
+
 	// DurationBeforeChangeTierRequestDeletion specifies the duration before a ChangeTierRequest resource is deleted
 	// +optional
 	DurationBeforeChangeTierRequestDeletion *string `json:"durationBeforeChangeTierRequestDeletion,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2124,6 +2124,11 @@ func (in *TiersConfig) DeepCopyInto(out *TiersConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DefaultSpaceTier != nil {
+		in, out := &in.DefaultSpaceTier, &out.DefaultSpaceTier
+		*out = new(string)
+		**out = **in
+	}
 	if in.DurationBeforeChangeTierRequestDeletion != nil {
 		in, out := &in.DurationBeforeChangeTierRequestDeletion, &out.DurationBeforeChangeTierRequestDeletion
 		*out = new(string)

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -2775,6 +2775,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_TiersConfig(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"defaultSpaceTier": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefaultSpaceTier specifies the default tier to assign for new spaces",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"durationBeforeChangeTierRequestDeletion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DurationBeforeChangeTierRequestDeletion specifies the duration before a ChangeTierRequest resource is deleted",


### PR DESCRIPTION
## Description
Adds a DefaultSpaceTier configuration field to Toolchainconfig.
Related Issue: https://issues.redhat.com/browse/CRT-1318

## Checks
1. Have you run `make generate` target? **[yes/no]** yes

2. Does `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]** yes

3. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#
