### PR TITLE
chore: fix typo in const name

### DIFF
--- a/api/v1alpha1/changetierrequest_types.go
+++ b/api/v1alpha1/changetierrequest_types.go
@@ -18,7 +18,7 @@ const (
 
 	// Status condition reasons
 	ChangeTierRequestChangedReason       = "Changed"
-	ChangeTierRequestChangeFiledReason   = "ChangeFailed"
+	ChangeTierRequestChangeFailedReason  = "ChangeFailed"
 	ChangeTierRequestDeletionErrorReason = "UnableToDeleteChangeTierRequest"
 )
 


### PR DESCRIPTION
See also https://github.com/codeready-toolchain/host-operator/pull/558

Not used anywhere else: https://github.com/search?q=org%3Acodeready-toolchain+ChangeTierRequestChangeFiledReason&type=code

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

