### PR TITLE
feat: introduce Space state label & make tierName optional

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -1,4 +1,14 @@
 package v1alpha1
 
-// LabelKeyPrefix is a string prefix which will be added to all label and annotation keys
-const LabelKeyPrefix = "toolchain.dev.openshift.com/"
+const (
+	// LabelKeyPrefix is a string prefix which will be added to all label and annotation keys
+	LabelKeyPrefix = "toolchain.dev.openshift.com/"
+
+	// StateLabelKey is used for setting the actual/expected state of an object like a UserSignup or a Space (not-ready, pending, banned, ...).
+	// The main purpose of the label is easy selecting the objects based on the state - eg. get all UserSignups or Spaces on the waiting list (state=pending).
+	// It may look like a duplication of the status conditions, but it more reflects the spec part combined with the actual state/configuration of the whole system.
+	StateLabelKey = LabelKeyPrefix + "state"
+
+	// StateLabelValuePending is used for identifying that the object is in a pending state.
+	StateLabelValuePending = "pending"
+)

--- a/api/v1alpha1/space_types.go
+++ b/api/v1alpha1/space_types.go
@@ -26,6 +26,14 @@ const (
 	SpaceUpdatingReason                    = updatingReason
 	SpaceRetargetingReason                 = "Retargeting"
 	SpaceRetargetingFailedReason           = "UnableToRetarget"
+
+	// SpaceStateLabelKey is used for setting the actual/expected state of Spaces (pending, or empty).
+	// The main purpose of the label is easy selecting the Spaces based on the state - eg. get all Spaces on the waiting list (state=pending).
+	SpaceStateLabelKey = StateLabelKey
+	// SpaceStateLabelValuePending is used for identifying that the Space is waiting for assigning an available cluster
+	SpaceStateLabelValuePending = StateLabelValuePending
+	// SpaceStateLabelValueClusterAssigned is used for identifying that the Space has an assigned cluster
+	SpaceStateLabelValueClusterAssigned = "cluster-assigned"
 )
 
 // SpaceSpec defines the desired state of Space
@@ -39,7 +47,9 @@ type SpaceSpec struct {
 
 	// TierName is a required property introduced to retain the name of the tier
 	// for which this Space is provisioned
-	TierName string `json:"tierName"`
+	// If not set then the tier name will be set automatically
+	// +optional
+	TierName string `json:"tierName,omitempty"`
 }
 
 // SpaceStatus defines the observed state of Space

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -50,14 +50,13 @@ const (
 	// UserSignupStateLabelKey is used for setting the required/expected state of UserSignups (not-ready, pending, approved, banned, deactivated).
 	// The main purpose of the label is easy selecting the UserSignups based on the state - eg. get all UserSignup on the waiting list (state=pending).
 	// Another usage of the label is counting the UserSingups for and exposing it through metrics or ToolchainStatus CR.
-	// It may look like a duplication of the status conditions, but it more reflects the spec part combined with the actual state/configuration of the whole system.
 	// Every value is set before doing the action - approving/deactivating/banning. The only exception is the "not-ready" state which is used as an initial state
 	// for all UserSignups that were just created and are still not fully ready - eg. requires verification.
-	UserSignupStateLabelKey = LabelKeyPrefix + "state"
+	UserSignupStateLabelKey = StateLabelKey
 	// UserSignupStateLabelValueNotReady is used for identifying that the UserSignup is not ready for approval yet (eg. requires verification)
 	UserSignupStateLabelValueNotReady = "not-ready"
 	// UserSignupStateLabelValuePending is used for identifying that the UserSignup is pending approval
-	UserSignupStateLabelValuePending = "pending"
+	UserSignupStateLabelValuePending = StateLabelValuePending
 	// UserSignupStateLabelValueApproved is used for identifying that the UserSignup is approved
 	UserSignupStateLabelValueApproved = "approved"
 	// UserSignupStateLabelValueDeactivated is used for identifying that the UserSignup is deactivated

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -2927,14 +2927,12 @@ func schema_codeready_toolchain_api_api_v1alpha1_SpaceSpec(ref common.ReferenceC
 					},
 					"tierName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TierName is a required property introduced to retain the name of the tier for which this Space is provisioned",
-							Default:     "",
+							Description: "TierName is a required property introduced to retain the name of the tier for which this Space is provisioned If not set then the tier name will be set automatically",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"tierName"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
This PR make two changes:
* makes the `Space.Spec.TierName` optional so it can be filled by the SpaceCompletionController as well
* adds Space state label key with two values:
   * pending - when Space doesn't have assigned any cluster
   * pending - when Space already have an assigned cluster
   
This will be used in two cases:
* capacity management
* metrics (counting how many Spaces are provisioned in which clusters)


I also introduced two generic contants for the `state` key and `pending` value because
* the values are the same as are used in `UserSignups` as well as in `Spaces`
* the capacity management will be generic to work with both types, so it will use this generic constant

## Checks
1. Did you run `make generate` target? **[yes/no]**

yes

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]**

yes

3. In case of **new** CRD, did you also update make/generate.mk in this repository and `resources/setup/roles/host.yaml` in the sandbox-sre repository?

N/A

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/584

another related PR:
https://github.com/codeready-toolchain/host-operator/pull/586
   