### PR TITLE
Introduce auto-create-space usersignup annotation

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -33,7 +33,7 @@ const (
 	UserVerificationAttemptsAnnotationKey = LabelKeyPrefix + "verification-attempts"
 	// UserVerificationExpiryAnnotationKey is used for the usersignup verification expiry annotation key
 	UserVerificationExpiryAnnotationKey = LabelKeyPrefix + "verification-expiry"
-	// SkipAutoCreateSpaceAnnotationKey when true signals the usersignup controller to skip Space creation, otherwise a Space will be created
+	// SkipAutoCreateSpaceAnnotationKey when true signals the usersignup controller to skip Space creation, otherwise a Space will be created by default
 	SkipAutoCreateSpaceAnnotationKey = LabelKeyPrefix + "skip-auto-create-space"
 
 	// UserSignupActivationCounterAnnotationKey is used for the usersignup activation counter annotation key

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -75,6 +75,8 @@ const (
 	UserSignupUnableToUpdateAnnotationReason       = "UnableToUpdateAnnotation"
 	UserSignupUnableToUpdateStateLabelReason       = "UnableToUpdateStateLabel"
 	UserSignupUnableToDeleteMURReason              = "UnableToDeleteMUR"
+	UserSignupUnableToCreateSpaceReason            = "UnableToCreateSpace"
+	UserSignupUnableToDeleteSpaceReason            = "UnableToDeleteSpace"
 
 	// The UserSignupUserDeactivatingReason constant will be replaced with UserSignupDeactivationInProgressReason
 	// in order to reduce ambiguity.  The "Deactivating" state should only refer to the period of time before the

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -33,8 +33,8 @@ const (
 	UserVerificationAttemptsAnnotationKey = LabelKeyPrefix + "verification-attempts"
 	// UserVerificationExpiryAnnotationKey is used for the usersignup verification expiry annotation key
 	UserVerificationExpiryAnnotationKey = LabelKeyPrefix + "verification-expiry"
-	// AutoCreateSpaceAnnotationKey when true signals the usersignup controller to create a Space, when false creating a Space will be skipped (default is true)
-	AutoCreateSpaceAnnotationKey = LabelKeyPrefix + "auto-create-space"
+	// SkipAutoCreateSpaceAnnotationKey when true signals the usersignup controller to skip Space creation, otherwise a Space will be created
+	SkipAutoCreateSpaceAnnotationKey = LabelKeyPrefix + "skip-auto-create-space"
 
 	// UserSignupActivationCounterAnnotationKey is used for the usersignup activation counter annotation key
 	// Activations are counted after phone verification succeeded

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -33,6 +33,8 @@ const (
 	UserVerificationAttemptsAnnotationKey = LabelKeyPrefix + "verification-attempts"
 	// UserVerificationExpiryAnnotationKey is used for the usersignup verification expiry annotation key
 	UserVerificationExpiryAnnotationKey = LabelKeyPrefix + "verification-expiry"
+	// AutoCreateSpaceAnnotationKey when true signals the usersignup controller to create a Space, when false creating a Space will be skipped
+	AutoCreateSpaceAnnotationKey = LabelKeyPrefix + "auto-create-space"
 
 	// UserSignupActivationCounterAnnotationKey is used for the usersignup activation counter annotation key
 	// Activations are counted after phone verification succeeded

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -33,7 +33,7 @@ const (
 	UserVerificationAttemptsAnnotationKey = LabelKeyPrefix + "verification-attempts"
 	// UserVerificationExpiryAnnotationKey is used for the usersignup verification expiry annotation key
 	UserVerificationExpiryAnnotationKey = LabelKeyPrefix + "verification-expiry"
-	// AutoCreateSpaceAnnotationKey when true signals the usersignup controller to create a Space, when false creating a Space will be skipped
+	// AutoCreateSpaceAnnotationKey when true signals the usersignup controller to create a Space, when false creating a Space will be skipped (default is true)
 	AutoCreateSpaceAnnotationKey = LabelKeyPrefix + "auto-create-space"
 
 	// UserSignupActivationCounterAnnotationKey is used for the usersignup activation counter annotation key


### PR DESCRIPTION
## Description
Adds the `toolchain.dev.openshift.com/skip-auto-create-space` annotation for usersignups that when true signals the usersignup controller to skip Space creation