### PR TITLE
refactoring: drop syncIndex from MUR

### DIFF
--- a/api/v1alpha1/masteruserrecord_types.go
+++ b/api/v1alpha1/masteruserrecord_types.go
@@ -96,10 +96,6 @@ type UserAccountEmbedded struct {
 	// The cluster in which the user exists
 	TargetCluster string `json:"targetCluster"`
 
-	// SyncIndex is to be updated by UserAccount Controller
-	// when the member needs to trigger MasterUserRecord <-> UserAccount synchronization
-	SyncIndex string `json:"syncIndex"`
-
 	// The spec of the corresponding UserAccount
 	Spec UserAccountSpecEmbedded `json:"spec"`
 }
@@ -143,10 +139,6 @@ type UserAccountStatusEmbedded struct {
 
 	// Cluster is the cluster in which the user exists
 	Cluster Cluster `json:"cluster"`
-
-	// SyncIndex is used for checking if there is needed some MasterUserRecord <-> UserAccount
-	// synchronization for this specific UserAccount in the specific member cluster
-	SyncIndex string `json:"syncIndex"`
 
 	// Inherits the status from the corresponding UserAccount status
 	UserAccountStatus `json:",inline"`


### PR DESCRIPTION
## Description
It drops the SyncIndex from MUR. This is the last step of https://issues.redhat.com/browse/CRT-1306

## Checks
1. Did you run `make generate` target? **[yes/no]**

**yes**

3. Did `make generate` change anything in other projects (host-operator, member-operator)? **[yes/no]**

**yes**

5. In case of **new** CRD, did you also update make/generate.mk in this repository and `resources/setup/roles/host.yaml` in the sandbox-sre repository?

N/A

7. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/620

related PRs:
* https://github.com/codeready-toolchain/toolchain-common/pull/246
* https://github.com/codeready-toolchain/host-operator/pull/620
* https://github.com/codeready-toolchain/member-operator/pull/353
* https://github.com/codeready-toolchain/toolchain-e2e/pull/529
