### PR TITLE
Default user tier

### DIFF
--- a/api/v1alpha1/toolchainconfig_types.go
+++ b/api/v1alpha1/toolchainconfig_types.go
@@ -372,6 +372,10 @@ type TiersConfig struct {
 	// +optional
 	DefaultTier *string `json:"defaultTier,omitempty"`
 
+	// DefaultUserTier specifies the default tier to assign for new users
+	// +optional
+	DefaultUserTier *string `json:"defaultUserTier,omitempty"`
+
 	// DefaultSpaceTier specifies the default tier to assign for new spaces
 	// +optional
 	DefaultSpaceTier *string `json:"defaultSpaceTier,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2476,6 +2476,11 @@ func (in *TiersConfig) DeepCopyInto(out *TiersConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DefaultUserTier != nil {
+		in, out := &in.DefaultUserTier, &out.DefaultUserTier
+		*out = new(string)
+		**out = **in
+	}
 	if in.DefaultSpaceTier != nil {
 		in, out := &in.DefaultSpaceTier, &out.DefaultSpaceTier
 		*out = new(string)

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -3368,6 +3368,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_TiersConfig(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"defaultUserTier": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefaultUserTier specifies the default tier to assign for new users",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"defaultSpaceTier": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DefaultSpaceTier specifies the default tier to assign for new spaces",


### PR DESCRIPTION
## Description
Adds a new config field for the "Default User Tier" since just "Default Tier" can be confused for either User or Space. `DefaultTier` will be removed in a following PR.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **n/a**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/636
