### PR TITLE
Add NoUserTierAvailable const

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -68,6 +68,7 @@ const (
 
 	// Status condition reasons
 	UserSignupNoClusterAvailableReason             = "NoClusterAvailable"
+	UserSignupNoUserTierAvailableReason            = "NoUserTierAvailable"
 	UserSignupNoTemplateTierAvailableReason        = "NoTemplateTierAvailable"
 	UserSignupFailedToReadUserApprovalPolicyReason = "FailedToReadUserApprovalPolicy"
 	UserSignupUnableToCreateMURReason              = "UnableToCreateMUR"


### PR DESCRIPTION
## Description

Just adds a `NoUserTierAvailable` reason for when a UserTier cannot be found during user signup.