### PR TITLE
Skip user creation config

### DIFF
--- a/api/v1alpha1/memberoperatorconfig_types.go
+++ b/api/v1alpha1/memberoperatorconfig_types.go
@@ -23,6 +23,10 @@ type MemberOperatorConfigSpec struct {
 	// +optional
 	Console ConsoleConfig `json:"console,omitempty"`
 
+	// Defines the flag that determines whether User and Identity resources should be created for a UserAccount
+	// +optional
+	SkipUserCreation *bool `json:"skipUserCreation,omitempty"`
+
 	// Keeps parameters concerned with member status
 	// +optional
 	MemberStatus MemberStatusConfig `json:"memberStatus,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -884,6 +884,11 @@ func (in *MemberOperatorConfigSpec) DeepCopyInto(out *MemberOperatorConfigSpec) 
 	in.Autoscaler.DeepCopyInto(&out.Autoscaler)
 	in.Che.DeepCopyInto(&out.Che)
 	in.Console.DeepCopyInto(&out.Console)
+	if in.SkipUserCreation != nil {
+		in, out := &in.SkipUserCreation, &out.SkipUserCreation
+		*out = new(bool)
+		**out = **in
+	}
 	in.MemberStatus.DeepCopyInto(&out.MemberStatus)
 	in.ToolchainCluster.DeepCopyInto(&out.ToolchainCluster)
 	in.Webhook.DeepCopyInto(&out.Webhook)

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1283,6 +1283,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_MemberOperatorConfigSpec(ref co
 							Ref:         ref("github.com/codeready-toolchain/api/api/v1alpha1.ConsoleConfig"),
 						},
 					},
+					"skipUserCreation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Defines the flag that determines whether User and Identity resources should be created for a UserAccount",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"memberStatus": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Keeps parameters concerned with member status",


### PR DESCRIPTION
## Description
Adds `SkipUserCreation` to the MemberOperatorConfig to control whether User and Identity resources should be created. This will primarily be used for the appstudio staging cluster to prevent appstudio tier users from User and Identities conflicts.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **n/a**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#
