### PR TITLE
Remove deactivation timeout days

### DIFF
--- a/api/v1alpha1/nstemplatetier_types.go
+++ b/api/v1alpha1/nstemplatetier_types.go
@@ -22,10 +22,6 @@ type NSTemplateTierSpec struct {
 	// +optional
 	// +mapType=atomic
 	SpaceRoles map[string]NSTemplateTierSpaceRole `json:"spaceRoles,omitempty"`
-
-	// the period (in days) after which users within the tier will be deactivated
-	// +optional
-	DeactivationTimeoutDays int `json:"deactivationTimeoutDays,omitempty"`
 }
 
 // NSTemplateTierNamespace the namespace definition in an NSTemplateTier resource

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1754,13 +1754,6 @@ func schema_codeready_toolchain_api_api_v1alpha1_NSTemplateTierSpec(ref common.R
 							},
 						},
 					},
-					"deactivationTimeoutDays": {
-						SchemaProps: spec.SchemaProps{
-							Description: "the period (in days) after which users within the tier will be deactivated",
-							Type:        []string{"integer"},
-							Format:      "int32",
-						},
-					},
 				},
 				Required: []string{"namespaces"},
 			},


### PR DESCRIPTION
## Description
Removes the `DeactivationTimeoutDays` field from the NSTemplateTier type. `DeactivationTimeoutDays` is now part of the `UserTier` type only.

Related Issue: https://issues.redhat.com/browse/ASC-49

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **n/a**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/666
    - toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/263
