### PR TITLE
Provisioning user signup

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -79,6 +79,7 @@ const (
 	UserSignupUnableToDeleteMURReason              = "UnableToDeleteMUR"
 	UserSignupUnableToCreateSpaceReason            = "UnableToCreateSpace"
 	UserSignupUnableToCreateSpaceBindingReason     = "UnableToCreateSpaceBinding"
+	UserSignupProvisioningSpace                    = "ProvisioningSpace"
 
 	// The UserSignupUserDeactivatingReason constant will be replaced with UserSignupDeactivationInProgressReason
 	// in order to reduce ambiguity.  The "Deactivating" state should only refer to the period of time before the

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -81,7 +81,6 @@ const (
 	UserSignupUnableToCreateSpaceBindingReason     = "UnableToCreateSpaceBinding"
 	UserSignupProvisioningSpaceReason              = "ProvisioningSpace"
 
-
 	// The UserSignupUserDeactivatingReason constant will be replaced with UserSignupDeactivationInProgressReason
 	// in order to reduce ambiguity.  The "Deactivating" state should only refer to the period of time before the
 	// user is deactivated (by default 3 days), not when the user is in the actual process of deactivation

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -11,8 +11,6 @@ const (
 	UserSignupApproved ConditionType = "Approved"
 	// UserSignupComplete means provisioning is complete
 	UserSignupComplete ConditionType = "Complete"
-	//UserSignupProvisioning means provisioning is in progress
-	UserSignupProvisioning ConditionType = "Provisioning"
 	// UserSignupUserDeactivatingNotificationCreated is used to track the status of the notification send to a user
 	// shortly before their account is due for deactivation
 	UserSignupUserDeactivatingNotificationCreated ConditionType = "UserDeactivatingNotificationCreated"

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -79,7 +79,7 @@ const (
 	UserSignupUnableToDeleteMURReason              = "UnableToDeleteMUR"
 	UserSignupUnableToCreateSpaceReason            = "UnableToCreateSpace"
 	UserSignupUnableToCreateSpaceBindingReason     = "UnableToCreateSpaceBinding"
-	UserSignupProvisioningSpace                    = "ProvisioningSpace"
+	UserSignupProvisioningSpaceReason              = "ProvisioningSpace"
 
 	// The UserSignupUserDeactivatingReason constant will be replaced with UserSignupDeactivationInProgressReason
 	// in order to reduce ambiguity.  The "Deactivating" state should only refer to the period of time before the

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -81,6 +81,7 @@ const (
 	UserSignupUnableToCreateSpaceBindingReason     = "UnableToCreateSpaceBinding"
 	UserSignupProvisioningSpaceReason              = "ProvisioningSpace"
 
+
 	// The UserSignupUserDeactivatingReason constant will be replaced with UserSignupDeactivationInProgressReason
 	// in order to reduce ambiguity.  The "Deactivating" state should only refer to the period of time before the
 	// user is deactivated (by default 3 days), not when the user is in the actual process of deactivation

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -11,6 +11,8 @@ const (
 	UserSignupApproved ConditionType = "Approved"
 	// UserSignupComplete means provisioning is complete
 	UserSignupComplete ConditionType = "Complete"
+	//UserSignupProvisioning means provisioning is in progress
+	UserSignupProvisioning ConditionType = "Provisioning"
 	// UserSignupUserDeactivatingNotificationCreated is used to track the status of the notification send to a user
 	// shortly before their account is due for deactivation
 	UserSignupUserDeactivatingNotificationCreated ConditionType = "UserDeactivatingNotificationCreated"


### PR DESCRIPTION
## Description
adding a condition type and condition reason to indicate usersignup provisioning is in progress.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **NA**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links. - **NA**
