### PR TITLE
Introduce another config param to allow notification sender to be

### DIFF
--- a/api/v1alpha1/toolchainconfig_types.go
+++ b/api/v1alpha1/toolchainconfig_types.go
@@ -334,6 +334,11 @@ type RegistrationServiceVerificationConfig struct {
 	// +optional
 	CodeExpiresInMin *int `json:"codeExpiresInMin,omitempty"`
 
+	// NotificationSender is used to specify which service should be used to send verification notifications. Allowed
+	// values are "twilio", "aws".  If not specified, the Twilio sender will be used.
+	// +optional
+	NotificationSender *string `json:"notificationSender,omitempty"`
+
 	// AWSRegion to use when sending notification SMS
 	// +optional
 	AWSRegion *string `json:"awsRegion,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1793,6 +1793,11 @@ func (in *RegistrationServiceVerificationConfig) DeepCopyInto(out *RegistrationS
 		*out = new(int)
 		**out = **in
 	}
+	if in.NotificationSender != nil {
+		in, out := &in.NotificationSender, &out.NotificationSender
+		*out = new(string)
+		**out = **in
+	}
 	if in.AWSRegion != nil {
 		in, out := &in.AWSRegion, &out.AWSRegion
 		*out = new(string)

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -2424,6 +2424,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_RegistrationServiceVerification
 							Format:      "int32",
 						},
 					},
+					"notificationSender": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NotificationSender is used to specify which service should be used to send verification notifications. Allowed values are \"twilio\", \"aws\".  If not specified, the Twilio sender will be used.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"awsRegion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AWSRegion to use when sending notification SMS",
@@ -2490,14 +2497,14 @@ func schema_codeready_toolchain_api_api_v1alpha1_RegistrationServiceVerification
 					},
 					"awsAccessKeyID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AWSAccessKeyId",
+							Description: "AWSAccessKeyId is the AWS Access Key used to authenticate in order to access AWS services",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"awsSecretAccessKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AWSSecretAccessKey",
+							Description: "AWSSecretAccessKey is the AWS credential used to authenticate in order to access AWS services",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
specified.

## Description
This PR introduces one additional configuration parameter that allows the notification sender service (either AWS or Twilio) to be set.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/685

