### PR TITLE
Use go install instead of go get

### DIFF
--- a/make/get-tool.mk
+++ b/make/get-tool.mk
@@ -21,7 +21,7 @@ define go-get-tool
 	cd $${TMP_DIR} ;\
 	go mod init tmp ;\
 	echo "Downloading ${2}" ;\
-	GOBIN=$(PROJECT_DIR)/bin go get ${2}@${3} ;\
+	GOBIN=$(PROJECT_DIR)/bin go install ${2}@${3} ;\
 	touch ${VERSIONS_FILE} ;\
 	sed '\|${2}|d' ${VERSIONS_FILE} > $${TMP_DIR}/versions ;\
 	mv $${TMP_DIR}/versions ${VERSIONS_FILE} ;\


### PR DESCRIPTION
## Description
This PR switches to use `go install` for downloading the tools used for codegen because `go get` has been deprecated for installing executables, see https://go.dev/doc/go-get-install-deprecation

As of go 1.17 `go get` tool does not download the binary and only modifies go.mod.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **n/a**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
n/a
