### PR TITLE
feat: add 'Subject' field in UserSignup

### DIFF
--- a/api/v1alpha1/masteruserrecord_types.go
+++ b/api/v1alpha1/masteruserrecord_types.go
@@ -56,7 +56,11 @@ type MasterUserRecordSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	// UserID is the user ID from RHD Identity Provider token (“sub” claim)
+	// The user's ID, obtained from the identity provider in the `sub` (subject) claim
+	Subject string `json:"subject"`
+
+	// The user ID, obtained from the identity provider in the `userID` claim.
+	// Note: most of the time, it will be the same as `Subject`
 	UserID string `json:"userID"`
 
 	// If set to true then the corresponding user should not be able to login (but the underlying UserAccounts still exists)

--- a/api/v1alpha1/useraccount_types.go
+++ b/api/v1alpha1/useraccount_types.go
@@ -31,8 +31,11 @@ type UserAccountSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	// UserID is the user ID from RHD Identity Provider token (“sub” claim)
-	// Is to be used to create Identity and UserIdentityMapping resources
+	// The user's ID, obtained from the identity provider in the `sub` (subject) claim
+	Subject string `json:"subject"`
+
+	// The user ID, obtained from the identity provider in the `userID` claim.
+	// Note: most of the time, it will be the same as `Subject`
 	UserID string `json:"userID"`
 
 	// If set to true then the corresponding user should not be able to login

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -167,7 +167,11 @@ type UserSignupSpec struct {
 	// +optional
 	TargetCluster string `json:"targetCluster,omitempty"`
 
-	// The user's user ID, obtained from the identity provider from the 'sub' (subject) claim
+	// The user's ID, obtained from the identity provider in the `sub` (subject) claim
+	Subject string `json:"subject"`
+
+	// The user ID, obtained from the identity provider in the `userID` claim.
+	// Note: most of the time, it will be the same as `Subject`
 	Userid string `json:"userid"`
 
 	// The user's username, obtained from the identity provider.

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -947,9 +947,17 @@ func schema_codeready_toolchain_api_api_v1alpha1_MasterUserRecordSpec(ref common
 				Description: "MasterUserRecordSpec defines the desired state of MasterUserRecord",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"subject": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's ID, obtained from the identity provider in the `sub` (subject) claim",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"userID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UserID is the user ID from RHD Identity Provider token (“sub” claim)",
+							Description: "The user ID, obtained from the identity provider in the `userID` claim. Note: most of the time, it will be the same as `Subject`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -999,7 +1007,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_MasterUserRecordSpec(ref common
 						},
 					},
 				},
-				Required: []string{"userID"},
+				Required: []string{"subject", "userID"},
 			},
 		},
 		Dependencies: []string{
@@ -3739,9 +3747,17 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserAccountSpec(ref common.Refe
 				Description: "UserAccountSpec defines the desired state of UserAccount",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"subject": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's ID, obtained from the identity provider in the `sub` (subject) claim",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"userID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UserID is the user ID from RHD Identity Provider token (“sub” claim) Is to be used to create Identity and UserIdentityMapping resources",
+							Description: "The user ID, obtained from the identity provider in the `userID` claim. Note: most of the time, it will be the same as `Subject`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3762,7 +3778,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserAccountSpec(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"userID"},
+				Required: []string{"subject", "userID"},
 			},
 		},
 	}
@@ -3868,9 +3884,17 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupSpec(ref common.Refer
 							Format:      "",
 						},
 					},
+					"subject": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The user's ID, obtained from the identity provider in the `sub` (subject) claim",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"userid": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The user's user ID, obtained from the identity provider from the 'sub' (subject) claim",
+							Description: "The user ID, obtained from the identity provider in the `userID` claim. Note: most of the time, it will be the same as `Subject`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3933,7 +3957,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupSpec(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"userid", "username"},
+				Required: []string{"subject", "userid", "username"},
 			},
 		},
 	}


### PR DESCRIPTION
This field will be populated with the 'sub' claim of the user's access token,
and the existing 'UserID' field will be filled with the 'userID' claim.

As a result, custom resource fields will be aligned with access token claims.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
