### PR TITLE
add parentSpace field in Space CRD and minor comment fix

### DIFF
--- a/api/v1alpha1/space_types.go
+++ b/api/v1alpha1/space_types.go
@@ -51,8 +51,9 @@ type SpaceSpec struct {
 	// +optional
 	TierName string `json:"tierName,omitempty"`
 
-	// ParentSpace holds the name of the context (Space) from which this space was created (requested)
-	// using the SpaceRequest mechanism.
+	// ParentSpace holds the name of the context (Space) from which this space was created (requested),
+	// enabling hierarchy relationships between different Spaces.
+	//
 	// Keeping this association brings two main benefits:
 	// 1. SpaceBindings are inherited from the parent Space
 	// 2. Ability to easily monitor quota for the requested sub-spaces

--- a/api/v1alpha1/space_types.go
+++ b/api/v1alpha1/space_types.go
@@ -45,11 +45,19 @@ type SpaceSpec struct {
 	// +optional
 	TargetCluster string `json:"targetCluster,omitempty"`
 
-	// TierName is a required property introduced to retain the name of the tier
+	// TierName is introduced to retain the name of the tier
 	// for which this Space is provisioned
 	// If not set then the tier name will be set automatically
 	// +optional
 	TierName string `json:"tierName,omitempty"`
+
+	// ParentSpace holds the name of the context (Space) from which this space was created (requested)
+	// using the SpaceRequest mechanism.
+	// Keeping this association brings two main benefits:
+	// 1. SpaceBindings are inherited from the parent Space
+	// 2. Ability to easily monitor quota for the requested sub-spaces
+	// +optional
+	ParentSpace string `json:"parentSpace,omitempty"`
 }
 
 // SpaceStatus defines the observed state of Space

--- a/api/v1alpha1/space_types.go
+++ b/api/v1alpha1/space_types.go
@@ -10,6 +10,10 @@ const (
 
 	// WorkspaceLabelKey is used to label the Space with the name of the associated AppStudio Workspace
 	WorkspaceLabelKey = LabelKeyPrefix + "workspace"
+
+	// ParentSpaceLabelKey is used to label the Space with the name of the parent space
+	// from which the creation was requested
+	ParentSpaceLabelKey = LabelKeyPrefix + "parent-space"
 )
 
 // These are valid status condition reasons of a Space

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -3171,7 +3171,14 @@ func schema_codeready_toolchain_api_api_v1alpha1_SpaceSpec(ref common.ReferenceC
 					},
 					"tierName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TierName is a required property introduced to retain the name of the tier for which this Space is provisioned If not set then the tier name will be set automatically",
+							Description: "TierName is introduced to retain the name of the tier for which this Space is provisioned If not set then the tier name will be set automatically",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"parentSpace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ParentSpace holds the name of the context (Space) from which this space was created (requested) using the SpaceRequest mechanism. Keeping this association brings two main benefits: 1. SpaceBindings are inherited from the parent Space 2. Ability to easily monitor quota for the requested sub-spaces",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -3178,7 +3178,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_SpaceSpec(ref common.ReferenceC
 					},
 					"parentSpace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ParentSpace holds the name of the context (Space) from which this space was created (requested) using the SpaceRequest mechanism. Keeping this association brings two main benefits: 1. SpaceBindings are inherited from the parent Space 2. Ability to easily monitor quota for the requested sub-spaces",
+							Description: "ParentSpace holds the name of the context (Space) from which this space was created (requested), enabling hierarchy relationships between different Spaces.\n\nKeeping this association brings two main benefits: 1. SpaceBindings are inherited from the parent Space 2. Ability to easily monitor quota for the requested sub-spaces",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
## Description
This PR adds `parentSpace` field to the `Space` CRD, covers the first acceptance criteria from https://issues.redhat.com/browse/ASC-247.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects? **yes**
host-operator

3. In case of **new** CRD, did you the following? **N/A**
N/A

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/723
 
