### PR TITLE
Add workspace type

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -22,6 +22,11 @@ type WorkspaceStatus struct {
 	// Role defines what kind of permissions the user has in the given workspace.
 	// +optional
 	Role string `json:"role,omitempty"`
+
+	// Type defines the type of workspace. For example, "home" for a user's given workspace upon first
+	// signing up. It is currently valid for this value to be empty.
+	// +optional
+	Type string `json:"type,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -4347,6 +4347,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_WorkspaceStatus(ref common.Refe
 							Format:      "",
 						},
 					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type defines the type of workspace. For example, \"home\" for a user's given workspace upon first signing up. It is currently valid for this value to be empty.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Adds "type" to Workspace CRD that can be used to identify a user's "home" workspace.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **n/a**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/409
