### PR TITLE
Added constants for user_id and account_id

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -17,6 +17,10 @@ const (
 	// UserSignupUserDeactivatedNotificationCreated means that the Notification CR was created so the user should be notified about their deactivated account
 	UserSignupUserDeactivatedNotificationCreated ConditionType = "UserDeactivatedNotificationCreated"
 
+	// UserSignupSSOUserIDAnnotationKey is used to store the user's user_id claim value issued by the SSO provider
+	UserSignupSSOUserIDAnnotationKey = LabelKeyPrefix + "sso-user-id"
+	// UserSignupSSOAccountIDAnnotationKey is used to store the user's account_id claim value issued by the SSO provider
+	UserSignupSSOAccountIDAnnotationKey = LabelKeyPrefix + "sso-account-id"
 	// UserSignupLastTargetClusterAnnotationKey is used for tracking the cluster for returning users
 	UserSignupLastTargetClusterAnnotationKey = LabelKeyPrefix + "last-target-cluster"
 	// UserSignupUserEmailAnnotationKey is used for the usersignup email annotations key


### PR DESCRIPTION
Adds constants for new annotation values for the purpose of storing a couple of SSO token claims used for Pendo integration.  No structural changes in this PR, constants only.

## Checks
1. Did you run `make generate` target? **no**  

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes/no**  N/A
