### PR TITLE
Implement creation of sub-spaces in SpaceRequest controller

### DIFF
--- a/api/v1alpha1/spacerequest_types.go
+++ b/api/v1alpha1/spacerequest_types.go
@@ -4,6 +4,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// SpaceRequestLabelKey is a label on the subSpace, and will hold the name of the SpaceRequest that created the subSpace resource.
+	SpaceRequestLabelKey = LabelKeyPrefix + "spaceRequest"
+)
+
 // SpaceRequestSpec defines the desired state of Space
 // +k8s:openapi-gen=true
 type SpaceRequestSpec struct {

--- a/api/v1alpha1/spacerequest_types.go
+++ b/api/v1alpha1/spacerequest_types.go
@@ -7,6 +7,8 @@ import (
 const (
 	// SpaceRequestLabelKey is a label on the subSpace, and will hold the name of the SpaceRequest that created the subSpace resource.
 	SpaceRequestLabelKey = LabelKeyPrefix + "spaceRequest"
+	// SpaceRequestNamespaceLabelKey is a label on the subSpace, and will hold the namespace of the SpaceRequest that created the subSpace resource.
+	SpaceRequestNamespaceLabelKey = LabelKeyPrefix + "spaceRequestNamespace"
 )
 
 // SpaceRequestSpec defines the desired state of Space

--- a/api/v1alpha1/spacerequest_types.go
+++ b/api/v1alpha1/spacerequest_types.go
@@ -6,9 +6,9 @@ import (
 
 const (
 	// SpaceRequestLabelKey is a label on the subSpace, and will hold the name of the SpaceRequest that created the subSpace resource.
-	SpaceRequestLabelKey = LabelKeyPrefix + "spaceRequest"
+	SpaceRequestLabelKey = LabelKeyPrefix + "spacerequest"
 	// SpaceRequestNamespaceLabelKey is a label on the subSpace, and will hold the namespace of the SpaceRequest that created the subSpace resource.
-	SpaceRequestNamespaceLabelKey = LabelKeyPrefix + "spaceRequestNamespace"
+	SpaceRequestNamespaceLabelKey = LabelKeyPrefix + "spacerequest-namespace"
 )
 
 // SpaceRequestSpec defines the desired state of Space


### PR DESCRIPTION
## Description
Add labels for linking Spaces to the SpaceRequest that provisioned them.

Jira: https://issues.redhat.com/browse/ASC-257

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **N/A**

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/770
    - e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/685
    - toolchain-cicd: https://github.com/codeready-toolchain/toolchain-cicd/pull/88
