### PR TITLE
fix: drop label WorkspaceLabelKey

### DIFF
--- a/api/v1alpha1/space_types.go
+++ b/api/v1alpha1/space_types.go
@@ -8,9 +8,6 @@ const (
 	// SpaceCreatorLabelKey is used to label the Space with the ID of its creator (Dev Sandbox UserSignup or AppStudio Workspace)
 	SpaceCreatorLabelKey = LabelKeyPrefix + "creator"
 
-	// WorkspaceLabelKey is used to label the Space with the name of the associated AppStudio Workspace
-	WorkspaceLabelKey = LabelKeyPrefix + "workspace"
-
 	// ParentSpaceLabelKey is used to label the Space with the name of the parent space
 	// from which the creation was requested
 	ParentSpaceLabelKey = LabelKeyPrefix + "parent-space"


### PR DESCRIPTION
## Description
Drop unused label `workspace` 

Part of Jira: https://issues.redhat.com/browse/SANDBOX-51 

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **N/A**

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/824
