### PR TITLE
Use constant for default namespace type

### DIFF
--- a/api/v1alpha1/spacenamespaces.go
+++ b/api/v1alpha1/spacenamespaces.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+const NamespaceTypeDefault = "default"
+
 // SpaceNamespace is a common type to define the information about a namespace within a Space
 // Used in NSTemplateSet, Space and Workspace status
 type SpaceNamespace struct {


### PR DESCRIPTION
## Description
Just introduces a constant for default namespace since we should probably use a common value in the different codebases. Having the common constant ensures we don't rename it and accidentally break other areas of the code.

It should be used in the following places:
- in the member operator nstemplateset code that sets the default namespace in Space Status: https://github.com/codeready-toolchain/member-operator/blob/450b77ca311fc11daa9a328d5cc62115f11a4ff7/controllers/nstemplateset/status.go#L74
- in the reg svc endpoint that looks up the default namespace for a user: https://github.com/codeready-toolchain/registration-service/blob/b8f6dfcc8a1e1080aa7f5ef35b5f6de12f507e59/pkg/signup/service/signup_service.go#L541

I can make the changes in those places once this PR is merged.
