### PR TITLE
Propagate email claim to downstream resources

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -212,9 +212,6 @@ type IdentityClaimsEmbedded struct {
 	// PreferredUsername contains the user's username
 	PreferredUsername string `json:"preferredUsername"`
 
-	// Email contains the user's email address
-	Email string `json:"email"`
-
 	// GivenName contains the value of the 'given_name' claim
 	// +optional
 	GivenName string `json:"givenName,omitempty"`
@@ -244,6 +241,9 @@ type PropagatedClaims struct {
 	// a new IdP provider client, and contains the user's "original-sub" claim
 	// +optional
 	OriginalSub string `json:"originalSub,omitempty"`
+
+	// Email contains the user's email address
+	Email string `json:"email"`
 }
 
 // UserSignupStatus defines the observed state of UserSignup

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -881,17 +881,17 @@ func schema_codeready_toolchain_api_api_v1alpha1_IdentityClaimsEmbedded(ref comm
 							Format:      "",
 						},
 					},
-					"preferredUsername": {
+					"email": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredUsername contains the user's username",
+							Description: "Email contains the user's email address",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"email": {
+					"preferredUsername": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Email contains the user's email address",
+							Description: "PreferredUsername contains the user's username",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -919,7 +919,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_IdentityClaimsEmbedded(ref comm
 						},
 					},
 				},
-				Required: []string{"sub", "preferredUsername", "email"},
+				Required: []string{"sub", "email", "preferredUsername"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
This PR adds the user's email address to the propagated claims copied down from UserSignup to other resources

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **yes/no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/861
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/473
