### PR TITLE
ci: bump actions to silence node12 warnings

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
         go-version: 1.19.x
         
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Lint
       uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
As of [June 2023][1], GitHub no longer uses node v12 within its actions runner by default.  They have been encouraging action authors to switch to node v16 and [encouraging users][2] to use the new versions of the actions when they become available, with the intent on removing node v12 sometime in the near future.

Bump the versions of the affected actions to bring this in line.

[1]: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
[2]: https://github.com/codeready-toolchain/host-operator/actions/runs/6421632076