### PR TITLE
Add HomeSpace status field

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -266,7 +266,8 @@ type UserSignupStatus struct {
 	// +optional
 	CompliantUsername string `json:"compliantUsername,omitempty"`
 
-	// HomeSpace represents the default home space for the user.
+	// HomeSpace is the name of the Space that is created for the user
+	// immediately after their account is approved.
 	// This is used by the proxy when no workspace context is provided.
 	// +optional
 	HomeSpace string `json:"homeSpace,omitempty"`

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -265,6 +265,11 @@ type UserSignupStatus struct {
 	// CompliantUsername is used to store the transformed, DNS-1123 compliant username
 	// +optional
 	CompliantUsername string `json:"compliantUsername,omitempty"`
+
+	// HomeSpace represents the default home space for the user.
+	// This is used by the proxy when no workspace context is provided.
+	// +optional
+	HomeSpace string `json:"homeSpace,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -4926,6 +4926,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupStatus(ref common.Ref
 							Format:      "",
 						},
 					},
+					"homeSpace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HomeSpace represents the default home space for the user. This is used by the proxy when no workspace context is provided.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -4928,7 +4928,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupStatus(ref common.Ref
 					},
 					"homeSpace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HomeSpace represents the default home space for the user. This is used by the proxy when no workspace context is provided.",
+							Description: "HomeSpace is the name of the Space that is created for the user immediately after their account is approved. This is used by the proxy when no workspace context is provided.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION

## Description

This field is going to be used by the proxy when no workspace context is provided.

Ref. Ref. https://issues.redhat.com/browse/SANDBOX-425

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/892

