### PR TITLE
print target cluster from status

### DIFF
--- a/api/v1alpha1/masteruserrecord_types.go
+++ b/api/v1alpha1/masteruserrecord_types.go
@@ -142,7 +142,7 @@ type Cluster struct {
 // +kubebuilder:resource:shortName=mur
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
-// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.spec.userAccounts[].targetCluster`
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.status.userAccounts[].cluster.name`
 // +kubebuilder:printcolumn:name="Tier",type="string",JSONPath=`.spec.tierName`
 // +kubebuilder:printcolumn:name="Banned",type="string",JSONPath=`.spec.banned`,priority=1
 // +kubebuilder:printcolumn:name="Disabled",type="string",JSONPath=`.spec.disabled`,priority=1


### PR DESCRIPTION
## Description
Take the target cluster the MUR is provisioned to from status

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **no**

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/952
