### PR TITLE
Revert change to make propagated claims required

### DIFF
--- a/api/v1alpha1/masteruserrecord_types.go
+++ b/api/v1alpha1/masteruserrecord_types.go
@@ -84,7 +84,8 @@ type MasterUserRecordSpec struct {
 
 	// PropagatedClaims contains a selection of claim values from the SSO Identity Provider which are intended to
 	// be "propagated" down the resource dependency chain
-	PropagatedClaims PropagatedClaims `json:"propagatedClaims"`
+	// +optional
+	PropagatedClaims PropagatedClaims `json:"propagatedClaims,omitempty"`
 }
 
 type UserAccountEmbedded struct {

--- a/api/v1alpha1/useraccount_types.go
+++ b/api/v1alpha1/useraccount_types.go
@@ -48,7 +48,8 @@ type UserAccountSpec struct {
 
 	// PropagatedClaims contains a selection of claim values from the SSO Identity Provider which are intended to
 	// be "propagated" down the resource dependency chain
-	PropagatedClaims PropagatedClaims `json:"propagatedClaims"`
+	// +optional
+	PropagatedClaims PropagatedClaims `json:"propagatedClaims,omitempty"`
 }
 
 // UserAccountStatus defines the observed state of UserAccount

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -201,7 +201,8 @@ type UserSignupSpec struct {
 	OriginalSub string `json:"originalSub,omitempty"`
 
 	// IdentityClaims contains as-is claim values extracted from the user's access token
-	IdentityClaims IdentityClaimsEmbedded `json:"identityClaims"`
+	// +optional
+	IdentityClaims IdentityClaimsEmbedded `json:"identityClaims,omitempty"`
 }
 
 // IdentityClaimsEmbedded is used to define a set of SSO claim values that we are interested in storing

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1299,7 +1299,6 @@ func schema_codeready_toolchain_api_api_v1alpha1_MasterUserRecordSpec(ref common
 						},
 					},
 				},
-				Required: []string{"propagatedClaims"},
 			},
 		},
 		Dependencies: []string{
@@ -4965,7 +4964,6 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserAccountSpec(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"propagatedClaims"},
 			},
 		},
 		Dependencies: []string{
@@ -5143,7 +5141,6 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupSpec(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"identityClaims"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## Description
This PR reverts the changes that made IdentityClaims / PropagatedClaims required.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **yes/no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/961
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/525
