### PR TITLE
Made IdentityClaims required

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -174,7 +174,6 @@ type UserSignupSpec struct {
 	States []UserSignupState `json:"states,omitempty"`
 
 	// IdentityClaims contains as-is claim values extracted from the user's access token
-	// +optional
 	IdentityClaims IdentityClaimsEmbedded `json:"identityClaims,omitempty"`
 }
 

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -174,7 +174,7 @@ type UserSignupSpec struct {
 	States []UserSignupState `json:"states,omitempty"`
 
 	// IdentityClaims contains as-is claim values extracted from the user's access token
-	IdentityClaims IdentityClaimsEmbedded `json:"identityClaims,omitempty"`
+	IdentityClaims IdentityClaimsEmbedded `json:"identityClaims"`
 }
 
 // IdentityClaimsEmbedded is used to define a set of SSO claim values that we are interested in storing

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -5122,6 +5122,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_UserSignupSpec(ref common.Refer
 						},
 					},
 				},
+				Required: []string{"identityClaims"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## Description
Made the UserSignup.Spec.IdentityClaims property required instead of optional

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **N/A**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/973
