### PR TITLE
add kubesaw-authenticated username constant

### DIFF
--- a/api/v1alpha1/auth.go
+++ b/api/v1alpha1/auth.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
 const (
+	// KubesawAuthenticatedUsername is the name of the special user
+	// used to identify a KubeSaw successfully authenticated user
 	KubesawAuthenticatedUsername string = "kubesaw-authenticated"
 )

--- a/api/v1alpha1/auth.go
+++ b/api/v1alpha1/auth.go
@@ -1,0 +1,5 @@
+package v1alpha1
+
+const (
+	KubesawAuthenticatedUsername string = "kubesaw-authenticated"
+)


### PR DESCRIPTION
Signed-off-by: Francesco Ilario <filario@redhat.com>

JIRA: https://issues.redhat.com/browse/ASC-531

## Description
This PR adds a constant value for the `kubesaw-authenticated` special user.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? N/A

4. In case other projects are changed, please provides PR links. N/A
