### PR TITLE
KUBESAW-43: Make LastProbeTime Optional

### DIFF
--- a/api/v1alpha1/toolchaincluster_types.go
+++ b/api/v1alpha1/toolchaincluster_types.go
@@ -104,6 +104,7 @@ type ToolchainClusterCondition struct {
 	// Status of the condition, one of True, False, Unknown.
 	Status corev1.ConditionStatus `json:"status"`
 	// Last time the condition was checked.
+	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime"`
 	// Last time the condition transit from one status to another.
 	// +optional

--- a/api/v1alpha1/toolchaincluster_types.go
+++ b/api/v1alpha1/toolchaincluster_types.go
@@ -106,6 +106,9 @@ type ToolchainClusterCondition struct {
 	// Last time the condition was checked.
 	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime"`
+	// Last time the condition was updated
+	// +optional
+	LastUpdatedTime *metav1.Time `json:"lastUpdatedTime,omitempty"`
 	// Last time the condition transit from one status to another.
 	// +optional
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3050,6 +3050,10 @@ func (in *ToolchainCluster) DeepCopyObject() runtime.Object {
 func (in *ToolchainClusterCondition) DeepCopyInto(out *ToolchainClusterCondition) {
 	*out = *in
 	in.LastProbeTime.DeepCopyInto(&out.LastProbeTime)
+	if in.LastUpdatedTime != nil {
+		in, out := &in.LastUpdatedTime, &out.LastUpdatedTime
+		*out = (*in).DeepCopy()
+	}
 	if in.LastTransitionTime != nil {
 		in, out := &in.LastTransitionTime, &out.LastTransitionTime
 		*out = (*in).DeepCopy()

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -4333,6 +4333,12 @@ func schema_codeready_toolchain_api_api_v1alpha1_ToolchainClusterCondition(ref c
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"lastUpdatedTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition was updated",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transit from one status to another.",

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -4354,7 +4354,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_ToolchainClusterCondition(ref c
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastProbeTime"},
+				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## Description
This is related to https://github.com/codeready-toolchain/host-operator/pull/1017#issuecomment-2082716929 . Making the LastProbeTime optional first

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **NA**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1022
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/563
