### PR TITLE
Add the definition of the toolchain-cluster label to the API so that it can be reused freely throughout the codebase.

### DIFF
--- a/api/v1alpha1/toolchaincluster_types.go
+++ b/api/v1alpha1/toolchaincluster_types.go
@@ -20,6 +20,10 @@ const (
 	ToolchainClusterClusterNotReadyReason     = "ClusterNotReady"
 	ToolchainClusterClusterNotReachableReason = "ClusterNotReachable"
 	ToolchainClusterClusterReachableReason    = "ClusterReachable"
+
+	// ToolchainClusterLabel is the label on the Secret containing the credentials to connect
+	// to the cluster represented by the ToolchainCluster object.
+	ToolchainClusterLabel = LabelKeyPrefix + "toolchain-cluster"
 )
 
 type TLSValidation string


### PR DESCRIPTION
## Description
A trivial PR to add the definition of the new label required for the implementation of https://issues.redhat.com/browse/KUBESAW-16. 

Related PRs:
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/396
- toolchain-cicd: https://github.com/codeready-toolchain/toolchain-cicd/pull/109
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1030
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/970

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **no, not a new CRD**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - no changes in the operators. This change is only related to the controller in the `toolchain-common`, see https://github.com/codeready-toolchain/toolchain-common/pull/396

