### PR TITLE
Trivial Add a new SPC Ready reason.

### DIFF
--- a/api/v1alpha1/spaceprovisionerconfig_types.go
+++ b/api/v1alpha1/spaceprovisionerconfig_types.go
@@ -4,6 +4,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 	SpaceProvisionerConfigToolchainClusterNotFoundReason = "ToolchainClusterNotFound"
+	SpaceProvisionerConfigToolchainClusterNotReadyReason = "ToolchainClusterNotReady"
 	SpaceProvisionerConfigValidReason                    = "AllChecksPassed"
 )
 


### PR DESCRIPTION
## Description
This adds a new reason for SpaceProvisionerConfig not being ready. As such this is no API change.

Related PRs:
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1033
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/977

## Checks
1. Did you run `make generate` target? **no, not needed**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**
