### PR TITLE
update webhook deploy comment

### DIFF
--- a/api/v1alpha1/memberoperatorconfig_types.go
+++ b/api/v1alpha1/memberoperatorconfig_types.go
@@ -156,7 +156,7 @@ type ToolchainClusterConfig struct {
 // +k8s:openapi-gen=true
 type WebhookConfig struct {
 	// Defines the flag that determines whether to deploy the Webhook.
-	// If the deploy flag is disabled, the Webhook is deployed and deleted immediately after by the memberoperatorconfig controller.
+	// If the deploy flag is set to False and the Webhook was deployed previously it will be deleted by the memberoperatorconfig controller.
 	// +optional
 	Deploy *bool `json:"deploy,omitempty"`
 

--- a/api/v1alpha1/memberoperatorconfig_types.go
+++ b/api/v1alpha1/memberoperatorconfig_types.go
@@ -155,7 +155,8 @@ type ToolchainClusterConfig struct {
 // Defines all parameters concerned with the Webhook
 // +k8s:openapi-gen=true
 type WebhookConfig struct {
-	// Defines the flag that determines whether to deploy the Webhook
+	// Defines the flag that determines whether to deploy the Webhook.
+	// If the deploy flag is disabled, the Webhook is deployed and deleted immediately after by the memberoperatorconfig controller.
 	// +optional
 	Deploy *bool `json:"deploy,omitempty"`
 

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -5213,7 +5213,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_WebhookConfig(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"deploy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Defines the flag that determines whether to deploy the Webhook",
+							Description: "Defines the flag that determines whether to deploy the Webhook. If the deploy flag is disabled, the Webhook is deployed and deleted immediately after by the memberoperatorconfig controller.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
## Description
Update the `WebhookConfig.Deploy` field which now is used in a different way. Based on the changes [in this PR](https://github.com/codeready-toolchain/member-operator/pull/562) and related ones, the webhook will still be deployed but deleted afterwords.

Those PRs will be merged only after the new behavior is merged to master. 

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **N/A**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1036
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/572
