### PR TITLE
Add recaptcha assessment id annotation

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -38,6 +38,8 @@ const (
 	UserSignupActivationCounterAnnotationKey = LabelKeyPrefix + "activation-counter"
 	// UserSignupCaptchaScoreAnnotationKey is set if captcha verification was used, and contains the last captcha assessment score for the user
 	UserSignupCaptchaScoreAnnotationKey = LabelKeyPrefix + "captcha-score"
+	// UserSignupCaptchaAssessmentIDAnnotationKey is set if captcha verification was used, and contains the last captcha assessment ID for the user
+	UserSignupCaptchaAssessmentIDAnnotationKey = LabelKeyPrefix + "captcha-assessment-id"
 
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
 	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"


### PR DESCRIPTION
## Description
Adds a constant to be used as an annotation key in the UserSignup.

eg.
```
apiVersion: toolchain.dev.openshift.com/v1alpha1
kind: UserSignup
metadata:
  annotations:
    toolchain.dev.openshift.com/captcha-assessment-id: "asdf-qwerty"
...
```

## Checks
1. Did you run `make generate` target? **yes/no** no, just added a constant

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **N/A**

3. In case of **new** CRD, did you the following? **N/A**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - reg svc changes will come in a separate PR
