### PR TITLE
Add an annotation to UserSignup for captcha annotated assessment

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -40,6 +40,8 @@ const (
 	UserSignupCaptchaScoreAnnotationKey = LabelKeyPrefix + "captcha-score"
 	// UserSignupCaptchaAssessmentIDAnnotationKey is set if captcha verification was used, and contains the last captcha assessment ID for the user
 	UserSignupCaptchaAssessmentIDAnnotationKey = LabelKeyPrefix + "captcha-assessment-id"
+	// UserSignupCaptchaAnnotatedAssessmentAnnotationKey is set if the last captcha assessment for the user was annotated as fraudulent or legitimate
+	UserSignupCaptchaAnnotatedAssessmentAnnotationKey = LabelKeyPrefix + "captcha-annotated-assessment"
 
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
 	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"


### PR DESCRIPTION
## Description
Adds a constant for the captcha annotated assessment to be used as an annotation key in the UserSignup.

https://issues.redhat.com/browse/SANDBOX-626

eg.
```
apiVersion: toolchain.dev.openshift.com/v1alpha1
kind: UserSignup
metadata:
  annotations:
    toolchain.dev.openshift.com/captcha-annotated-assessment: "FRAUDULENT"
...
```

The other possible value is `LEGITIMATE`


## Checks
1. Did you run `make generate` target? **no**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1043
