### PR TITLE
SANDBOX-677 use go-version-file

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,13 +14,13 @@ jobs:
     name: GolangCI Lint
     runs-on: ubuntu-20.04
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
     
     - name: Lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version-file: go.mod
         
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Description
uses go-version-file instead of go-version. One less place to change when making updates.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **N/A**

4. In case other projects are changed, please provides PR links. **N/A**
