### PR TITLE
add go reference card and delete codecov card

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = ToolChain API
 
 image:https://goreportcard.com/badge/github.com/codeready-toolchain/api[Go Report Card, link="https://goreportcard.com/report/github.com/codeready-toolchain/api"]
-image:https://codecov.io/gh/codeready-toolchain/api/branch/master/graph/badge.svg[Codecov.io,link="https://codecov.io/gh/codeready-toolchain/api"]
+image:https://godoc.org/github.com/codeready-toolchain/api?status.png[GoDoc,link="https://godoc.org/github.com/codeready-toolchain/api"]
 
 For the API reference docs go xref:api/v1alpha1/docs/apiref.adoc[here]
 


### PR DESCRIPTION
# Description
In order to be align with the other repos, this PR adds the go reference card to the README.
It also deletes codecov card since I think is unnecessary in this repo context.