### PR TITLE
SANDBOX-674: add BannedByLabelKey

### DIFF
--- a/api/v1alpha1/banneduser_types.go
+++ b/api/v1alpha1/banneduser_types.go
@@ -8,8 +8,11 @@ const (
 	// BannedUserEmailHashLabelKey is used for the banneduser email hash label key
 	BannedUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"
 
-	// BannedUserPhoneNumberHashLabelKey is used a label key for the hash of a phone of the banned user
+	// BannedUserPhoneNumberHashLabelKey is used for the banneduser phone number hash label key
 	BannedUserPhoneNumberHashLabelKey = LabelKeyPrefix + "phone-hash"
+
+	// BannedByLabelKey is used for the banned by label key (to point out who banned the user)
+	BannedByLabelKey = LabelKeyPrefix + "banned-by"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
## Description
add `BannedByLabelKey` to avoid duplication and mismatches across repos

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **NA**

4. In case other projects are changed, please provides PR links. **NA**


## Issue ticket number and link
[SANDBOX-674](https://issues.redhat.com/browse/SANDBOX-674)