### PR TITLE
Add CPU to Autoscaler buffer

### DIFF
--- a/api/v1alpha1/docs/apiref.adoc
+++ b/api/v1alpha1/docs/apiref.adoc
@@ -129,6 +129,7 @@ Defines all parameters concerned with the autoscaler
 | Field | Description | Default | Validation
 | *`deploy`* __boolean__ | Defines the flag that determines whether to deploy the autoscaler buffer + |  | 
 | *`bufferMemory`* __string__ | Represents how much memory should be required by the autoscaler buffer + |  | 
+| *`bufferCPU`* __string__ | Represents how much CPU should be required by the autoscaler buffer + |  | 
 | *`bufferReplicas`* __integer__ | Represents the number of autoscaler buffer replicas to request + |  | 
 |===
 

--- a/api/v1alpha1/memberoperatorconfig_types.go
+++ b/api/v1alpha1/memberoperatorconfig_types.go
@@ -63,6 +63,10 @@ type AutoscalerConfig struct {
 	// +optional
 	BufferMemory *string `json:"bufferMemory,omitempty"`
 
+	// Represents how much CPU should be required by the autoscaler buffer
+	// +optional
+	BufferCPU *string `json:"bufferCPU,omitempty"`
+
 	// Represents the number of autoscaler buffer replicas to request
 	// +optional
 	BufferReplicas *int `json:"bufferReplicas,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -67,6 +67,11 @@ func (in *AutoscalerConfig) DeepCopyInto(out *AutoscalerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BufferCPU != nil {
+		in, out := &in.BufferCPU, &out.BufferCPU
+		*out = new(string)
+		**out = **in
+	}
 	if in.BufferReplicas != nil {
 		in, out := &in.BufferReplicas, &out.BufferReplicas
 		*out = new(int)

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -215,6 +215,13 @@ func schema_codeready_toolchain_api_api_v1alpha1_AutoscalerConfig(ref common.Ref
 							Format:      "",
 						},
 					},
+					"bufferCPU": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Represents how much CPU should be required by the autoscaler buffer",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"bufferReplicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents the number of autoscaler buffer replicas to request",


### PR DESCRIPTION
This PR introduces an additional param to member configuration to manage CPU requests/limits in our Autoscaler buffer.
See https://issues.redhat.com/browse/SANDBOX-659 for more details.

Related PRs:
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1070
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/591
