### PR TITLE
Add target cluster to social event

### DIFF
--- a/api/v1alpha1/docs/apiref.adoc
+++ b/api/v1alpha1/docs/apiref.adoc
@@ -2382,7 +2382,8 @@ may register for the event by using the event's unique activation code
 This must be the valid name of an nstemplatetier resource. + |  | 
 | *`spaceTier`* __string__ | The tier to assign to spaces created for users who registered for the event. +
 This must be the valid name of an nstemplatetier resource. + |  | 
-| *`preferSameCluster`* __boolean__ | If true, best effort is made to provision all attendees of the event on the same cluster + |  | 
+| *`targetCluster`* __string__ | The cluster in which the user/space should be provisioned in +
+If not set then the target cluster will be picked automatically + |  | 
 | *`verificationRequired`* __boolean__ | If true, the user will also be required to complete standard phone verification + |  | 
 |===
 

--- a/api/v1alpha1/socialevent_types.go
+++ b/api/v1alpha1/socialevent_types.go
@@ -46,9 +46,10 @@ type SocialEventSpec struct {
 	// This must be the valid name of an nstemplatetier resource.
 	SpaceTier string `json:"spaceTier"`
 
-	// If true, best effort is made to provision all attendees of the event on the same cluster
+	// The cluster in which the user/space should be provisioned in
+	// If not set then the target cluster will be picked automatically
 	// +optional
-	PreferSameCluster bool `json:"preferSameCluster,omitempty"`
+	TargetCluster string `json:"targetCluster,omitempty"`
 
 	// If true, the user will also be required to complete standard phone verification
 	// +optional

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -3294,10 +3294,10 @@ func schema_codeready_toolchain_api_api_v1alpha1_SocialEventSpec(ref common.Refe
 							Format:      "",
 						},
 					},
-					"preferSameCluster": {
+					"targetCluster": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If true, best effort is made to provision all attendees of the event on the same cluster",
-							Type:        []string{"boolean"},
+							Description: "The cluster in which the user/space should be provisioned in If not set then the target cluster will be picked automatically",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},


### PR DESCRIPTION
Replaces `PreferSameCluster`, which is not currently used at all, by `TargetCluster`

Part of https://issues.redhat.com/browse/SANDBOX-724

- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1075
