### PR TITLE
SANDBOX-681: add 'Reason' field to BannedUserSpec

### DIFF
--- a/api/v1alpha1/banneduser_types.go
+++ b/api/v1alpha1/banneduser_types.go
@@ -26,9 +26,9 @@ type BannedUserSpec struct {
 	// The e-mail address of the account that has been banned
 	Email string `json:"email"`
 
-	// Description about the ban reasons
+	// Reason of the ban
 	// +optional
-	Description string `json:"description,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/banneduser_types.go
+++ b/api/v1alpha1/banneduser_types.go
@@ -27,7 +27,8 @@ type BannedUserSpec struct {
 	Email string `json:"email"`
 
 	// Description about the ban reasons
-	Description string `json:"description"`
+	// +optional
+	Description string `json:"description,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/banneduser_types.go
+++ b/api/v1alpha1/banneduser_types.go
@@ -25,6 +25,9 @@ type BannedUserSpec struct {
 
 	// The e-mail address of the account that has been banned
 	Email string `json:"email"`
+
+	// Description about the ban reasons
+	Description string `json:"description"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/docs/apiref.adoc
+++ b/api/v1alpha1/docs/apiref.adoc
@@ -201,6 +201,7 @@ BannedUserSpec defines the desired state of BannedUser
 |===
 | Field | Description | Default | Validation
 | *`email`* __string__ | The e-mail address of the account that has been banned + |  | 
+| *`description`* __string__ | Description about the ban reasons + |  | 
 |===
 
 

--- a/api/v1alpha1/docs/apiref.adoc
+++ b/api/v1alpha1/docs/apiref.adoc
@@ -201,7 +201,7 @@ BannedUserSpec defines the desired state of BannedUser
 |===
 | Field | Description | Default | Validation
 | *`email`* __string__ | The e-mail address of the account that has been banned + |  | 
-| *`description`* __string__ | Description about the ban reasons + |  | 
+| *`reason`* __string__ | Reason of the ban + |  | 
 |===
 
 

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -291,9 +291,9 @@ func schema_codeready_toolchain_api_api_v1alpha1_BannedUserSpec(ref common.Refer
 							Format:      "",
 						},
 					},
-					"description": {
+					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Description about the ban reasons",
+							Description: "Reason of the ban",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -291,8 +291,16 @@ func schema_codeready_toolchain_api_api_v1alpha1_BannedUserSpec(ref common.Refer
 							Format:      "",
 						},
 					},
+					"description": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Description about the ban reasons",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"email"},
+				Required: []string{"email", "description"},
 			},
 		},
 	}

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -294,13 +294,12 @@ func schema_codeready_toolchain_api_api_v1alpha1_BannedUserSpec(ref common.Refer
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Description about the ban reasons",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"email", "description"},
+				Required: []string{"email"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
To know why the user was banned, the `Reason` field should be added to `BannedUserSpec`.

## Checks
1. Did you run `make generate` target? yes

2. Did `make generate` change anything in other projects (host-operator, member-operator)? yes

4. In case of **new** CRD, did you the following?  no
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

5. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1081


## Issue ticket number and link
[SANDBOX-681](https://issues.redhat.com/browse/SANDBOX-681)