### PR TITLE
KUBESAW-192: Introduce a make command for pre-requisite of verify-replace script

### DIFF
--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -20,6 +20,10 @@ do
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
+    if ! make pre-verify; then
+        ERRORLIST+="($(basename ${repo}))"
+        continue
+    fi
     echo "Initiating 'go mod replace' of current api version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/api=${C_PATH}
     make verify-dependencies || ERRORLIST+="($(basename ${repo}))"


### PR DESCRIPTION
## Description
Introduce a make command for pre-requisite of verify-replace script as host-operator and member operator require tiers and assets to be ready before any changes to go mod

Initially this was not required for the api repo, but now this same error started appearing while running from api repo too hence updating the script to be similar to toolchain common - https://github.com/codeready-toolchain/toolchain-common/pull/429 

## Checks
1. Did you run `make generate` target? **NA**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **NA**

3. In case of **new** CRD, did you the following? **NA**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/429 
