### PR TITLE
KUBESAW-250: Updating GolangCiLint  to v1.63.1

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.52.0
+        version: v1.63.1
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose


### PR DESCRIPTION
## Description
Updating the GolangciLint  to v1.63.1 across all repos and fixing the linter error if any from this upgrade

Similar PRs -
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1116
- Toolchain-Common - https://github.com/codeready-toolchain/toolchain-common/pull/442
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/612
- Registration Service - https://github.com/codeready-toolchain/registration-service/pull/491
- Toolchain E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1092
- Ksctl - https://github.com/kubesaw/ksctl/pull/97

## Checks
1. Did you run `make generate` target? **NA**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **NA**

3. In case of **new** CRD, did you the following? **NA**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
   
