### PR TITLE
KUBESAW-174: Print error output for repos where verification failed

### DIFF
--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -9,7 +9,9 @@ ERROR_REPO_LIST=()
 ERROR_FILE_LIST=()
 STD_OUT_FILE_LIST=()
 GO_LINT_REGEX="[\s\w.\/]*:[0-9]*:[0-9]*:[\w\s)(*.\`]*"
-ERROR_REGEX="Error[:]*/|FAIL[:]*" #unit test or any other failure we log from our controllers other places goes into stdoutput, hence making that regex too, to fetch the error more precisely
+ERROR_REGEX="[E\|e][R\|r][R\|r][O\|o][R\|r][:]*\|[F\|f][A\|a][I\|i][l\|L][:]*\|expected[:]*\|actual[:]*" #unit test or any other failure we log from our controllers or other places goes into stdoutput 
+                                                            #(since we log it and its not a failure in running the command or dependency check), 
+                                                            #hence making that regex too, to fetch the error more precisely
 
 echo Initiating verify-replace on dependent repos
 for repo in "${REPOS[@]}"

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -55,23 +55,23 @@ if [ ${#ERROR_REPO_LIST[@]} -ne 0 ]; then
     echo "Below are the repos with error: "
     for error_repo_name in ${ERROR_REPO_LIST[*]}
     do
+        echo                                                          
+        echo =========================================================================================
+        echo 
+        echo                       "${error_repo_name} has the following errors "
+        echo                                                          
+        echo =========================================================================================
+        echo
         for error_file_name in ${ERROR_FILE_LIST[*]}
         do
             if [[ ${error_file_name} =~ ${error_repo_name} ]]; then 
-                echo                                                          
-                echo =========================================================================================
-                echo 
-                echo                       "${error_repo_name} has the following errors "
-                echo                                                          
-                echo =========================================================================================
-                echo 
                 cat "${error_file_name}"
             fi
         done
         for std_out_file_name in ${STD_OUT_FILE_LIST[*]}
             do
                 if [[ ${std_out_file_name} =~ ${error_repo_name} ]]; then 
-                    cat "${std_out_file_name}" | grep "${GO_LINT_REGEX}\|${ERROR_REGEX}"
+                    cat "${std_out_file_name}" | grep -C 5 "${GO_LINT_REGEX}\|${ERROR_REGEX}"
                 fi
         done                                             
     done

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -63,9 +63,9 @@ if [ ${#ERRORREPOLIST[@]} -ne 0 ]; then
                 for s in ${STDOUTFILELIST[*]}
                 do
                     if [[ ${s} =~ ${e} ]]; then 
-                        cat "${s}" | grep -E ${GOLINTREGEX} > lintererror
-                        if ! [ -s "lintererror" ]; then
-                            cat  lintererror   
+                        cat "${s}" | grep -E ${GOLINTREGEX} > LINTERERRORFILE
+                        if ! [ -s "LINTERERRORFILE" ]; then
+                            cat  LINTERERRORFILE   
                         fi
                     fi
                 done                                            

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -9,8 +9,7 @@ ERROR_REPO_LIST=()
 ERROR_FILE_LIST=()
 STD_OUT_FILE_LIST=()
 GO_LINT_REGEX="[\s\w.\/]*:[0-9]*:[0-9]*:[\w\s)(*.\`]*"
-ERROR_REGEX="Error[:]*" #unit test or any other failure we log goes into stdoutput, hence making that regex too to fetch the error
-FAIL_REGEX="FAIL[:]*" #unit test or any other failure we log goes into stdoutput, hence making that regex too to fetch the error
+ERROR_REGEX="Error[:]*/|FAIL[:]*" #unit test or any other failure we log from our controllers other places goes into stdoutput, hence making that regex too, to fetch the error more precisely
 
 echo Initiating verify-replace on dependent repos
 for repo in "${REPOS[@]}"
@@ -70,7 +69,7 @@ if [ ${#ERROR_REPO_LIST[@]} -ne 0 ]; then
         for std_out_file_name in ${STD_OUT_FILE_LIST[*]}
             do
                 if [[ ${std_out_file_name} =~ ${error_repo_name} ]]; then 
-                    cat "${std_out_file_name}" | grep -E ${GO_LINT_REGEX}|${ERROR_REGEX}|${FAIL_REGEX}
+                    cat "${std_out_file_name}" | grep -E ${GO_LINT_REGEX}|${ERROR_REGEX}
                 fi
         done                                             
     done

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -5,7 +5,10 @@ GH_BASE_URL_KS=https://github.com/kubesaw/
 GH_BASE_URL_CRT=https://github.com/codeready-toolchain/
 declare -a REPOS=("${GH_BASE_URL_KS}ksctl" "${GH_BASE_URL_CRT}host-operator" "${GH_BASE_URL_CRT}member-operator" "${GH_BASE_URL_CRT}registration-service" "${GH_BASE_URL_CRT}toolchain-e2e" "${GH_BASE_URL_CRT}toolchain-common")
 C_PATH=${PWD}
-ERRORLIST=()
+ERRORREPOLIST=()
+ERRORFILELIST=()
+GOLINTREGEX="[\s\w.\/]*:[0-9]*:[0-9]*:[\s\w]*[:]*[\s\w\">.-]*[\w\s)(*.]*"
+ERRORREGEX="Error[:]*"
 
 echo Initiating verify-replace on dependent repos
 for repo in "${REPOS[@]}"
@@ -16,26 +19,44 @@ do
     echo                                                                     
     echo =========================================================================================
     repo_path=${BASE_REPO_PATH}/$(basename ${repo})
+    ERRFILE=$(mktemp ${TMP_DIR}$(basename ${repo}).XXX)
     echo "Cloning repo in /tmp"
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
     if ! make pre-verify; then
-        ERRORLIST+="($(basename ${repo}))"
+        ERRORREPOLIST+="($(basename ${repo}))"
         continue
     fi
     echo "Initiating 'go mod replace' of current api version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/api=${C_PATH}
-    make verify-dependencies || ERRORLIST+="($(basename ${repo}))"
+    make verify-dependencies &> ${ERRFILE} 
+    rc=$?
+    if [ ${rc} -ne 0 ]; then
+    ERRORREPOLIST+="($(basename ${repo}))" 
+    ERRORFILELIST+="${ERRFILE}  "
+    fi
     echo                                                          
     echo =========================================================================================
     echo 
 done
-if [ ${#ERRORLIST[@]} -ne 0 ]; then
+echo "Summary"
+if [ ${#ERRORREPOLIST[@]} -ne 0 ]; then
     echo "Below are the repos with error: "
-    for e in ${ERRORLIST[*]}
+    for e in ${ERRORREPOLIST[*]}
     do
         echo "${e}"
+    done
+    for c in ${ERRORFILELIST[*]}
+    do  
+        echo                                                          
+        echo =========================================================================================
+        echo 
+        echo "${c} has the following errors "
+        echo                                                          
+        echo =========================================================================================
+        echo
+        cat "${c}" | grep "${GOLINTREGEX}\|${ERRORREGEX}"
     done
     exit 1
 else

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -63,9 +63,9 @@ if [ ${#ERRORREPOLIST[@]} -ne 0 ]; then
                 for s in ${STDOUTFILELIST[*]}
                 do
                     if [[ ${s} =~ ${e} ]]; then 
-                        cat "${s}" | grep -E ${GOLINTREGEX} > LINTERERRORFILE
-                        if ! [ -s "LINTERERRORFILE" ]; then
-                            cat  LINTERERRORFILE   
+                        cat "${s}" | grep -E ${GOLINTREGEX} > ${LINTERERRORFILE}
+                        if ! [ -s "${LINTERERRORFILE}" ]; then
+                            cat  "${LINTERERRORFILE}"  
                         fi
                     fi
                 done                                            

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -7,7 +7,7 @@ declare -a REPOS=("${GH_BASE_URL_KS}ksctl" "${GH_BASE_URL_CRT}host-operator" "${
 C_PATH=${PWD}
 ERRORREPOLIST=()
 ERRORFILELIST=()
-GOLINTREGEX="[\s\w.\/]*:[0-9]*:[0-9]*:[\s\w]*[:]*[\s\w\">.-]*[\w\s)(*.]*"
+GOLINTREGEX="[\s\w.\/]*:[0-9]*:[0-9]*:[\w\s)(*.\`]*"
 ERRORREGEX="Error[:]*"
 
 echo Initiating verify-replace on dependent repos
@@ -19,13 +19,13 @@ do
     echo                                                                     
     echo =========================================================================================
     repo_path=${BASE_REPO_PATH}/$(basename ${repo})
-    ERRFILE=$(mktemp ${TMP_DIR}$(basename ${repo}).XXX)
+    ERRFILE=$(mktemp ${TMP_DIR}$(basename ${repo})-error.XXX)
     echo "Cloning repo in /tmp"
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
     if ! make pre-verify; then
-        ERRORREPOLIST+="($(basename ${repo}))"
+        ERRORREPOLIST+="$(basename ${repo}) "
         continue
     fi
     echo "Initiating 'go mod replace' of current api version in dependent repos"
@@ -33,14 +33,14 @@ do
     make verify-dependencies &> ${ERRFILE} 
     rc=$?
     if [ ${rc} -ne 0 ]; then
-    ERRORREPOLIST+="($(basename ${repo}))" 
+    ERRORREPOLIST+="$(basename ${repo}) " 
     ERRORFILELIST+="${ERRFILE}  "
     fi
     echo                                                          
     echo =========================================================================================
     echo 
 done
-echo "Summary"
+echo                "Summary"
 if [ ${#ERRORREPOLIST[@]} -ne 0 ]; then
     echo "Below are the repos with error: "
     for e in ${ERRORREPOLIST[*]}
@@ -52,7 +52,7 @@ if [ ${#ERRORREPOLIST[@]} -ne 0 ]; then
         echo                                                          
         echo =========================================================================================
         echo 
-        echo "${c} has the following errors "
+        echo                       "${c} has the following errors "
         echo                                                          
         echo =========================================================================================
         echo

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -71,7 +71,7 @@ if [ ${#ERROR_REPO_LIST[@]} -ne 0 ]; then
         for std_out_file_name in ${STD_OUT_FILE_LIST[*]}
             do
                 if [[ ${std_out_file_name} =~ ${error_repo_name} ]]; then 
-                    cat "${std_out_file_name}" | grep -E ${GO_LINT_REGEX}|${ERROR_REGEX}
+                    cat "${std_out_file_name}" | grep "${GO_LINT_REGEX}\|${ERROR_REGEX}"
                 fi
         done                                             
     done


### PR DESCRIPTION
## Description
This PR is to update the verify dependency script such a way that it prints the error/failure in an understandable way

## Checks
1. Did you run `make generate` target? **NA**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **NA**

3. In case of **new** CRD, did you the following? **NA**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - Toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/450
