### PR TITLE
update Golanci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-service:
-  project-path: github.com/codeready-toolchain/api
-
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m


### PR DESCRIPTION
## Description
The Golanci-lint action recently changed the golangci-lint verify command to by default be true. [Change](https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0)

This broke our Golanci-lint CI [errorrepo1](https://github.com/codeready-toolchain/toolchain-common/actions/runs/13364924316/job/37328247752?pr=454#step:4:37).

The fix is to remove the additional parameter which the verify doesn't allow

## Checks
1. Did you run `make generate` target? **no**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
 
