### PR TITLE
add request-received-time annotation key

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -43,6 +43,9 @@ const (
 	// UserSignupCaptchaAnnotatedAssessmentAnnotationKey is set if the last captcha assessment for the user was annotated as fraudulent or legitimate
 	UserSignupCaptchaAnnotatedAssessmentAnnotationKey = LabelKeyPrefix + "captcha-annotated-assessment"
 
+	// UserSignupRequestReceivedTimeAnnotationKey is used for the timestamp when the request to create/reactivate UserSignup was received (stored in time.RFC3339 format)
+	UserSignupRequestReceivedTimeAnnotationKey = LabelKeyPrefix + "request-received-time"
+
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key
 	UserSignupUserEmailHashLabelKey = LabelKeyPrefix + "email-hash"
 	// UserSignupUserPhoneHashLabelKey is used for the usersignup phone hash label key

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -43,7 +43,8 @@ const (
 	// UserSignupCaptchaAnnotatedAssessmentAnnotationKey is set if the last captcha assessment for the user was annotated as fraudulent or legitimate
 	UserSignupCaptchaAnnotatedAssessmentAnnotationKey = LabelKeyPrefix + "captcha-annotated-assessment"
 
-	// UserSignupRequestReceivedTimeAnnotationKey is used for the timestamp when the request to create/reactivate UserSignup was received (stored in time.RFC3339 format)
+	// UserSignupRequestReceivedTimeAnnotationKey is used for the timestamp when the request to create/reactivate UserSignup was received
+	// The time is stored in time.RFC3339 format, the reason is that the main purpose of the metric is to track the UX of the users, and milliseconds don't really matter in that case
 	UserSignupRequestReceivedTimeAnnotationKey = LabelKeyPrefix + "request-received-time"
 
 	// UserSignupUserEmailHashLabelKey is used for the usersignup email hash label key


### PR DESCRIPTION
## Description
Adds an annotation key that will keep the time of the signup request.
[SANDBOX-957](https://issues.redhat.com/browse/SANDBOX-957)

## Checks
1. Did you run `make generate` target? **yes/no**

**NO** because adding annotation key doesn't require generating anything :smile: 
