### PR TITLE
update the golangci-lint version in the verify-dependencies GH action

### DIFF
--- a/.github/workflows/verify-dependencies.yml
+++ b/.github/workflows/verify-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install golangci-lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.1
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2
 
     - name: Verify
       run: |


### PR DESCRIPTION
update the golangci-lint version in the verify-dependencies GH action to be in line with the version in linters.yaml
