### PR TITLE
clean envs used in fake GOPATH hack

### DIFF
--- a/make/generate.mk
+++ b/make/generate.mk
@@ -29,7 +29,7 @@ gen-crd-ref-docs: crd-ref-docs
 .PHONY: generate-openapi
 generate-openapi: openapi-gen
 	@echo "re-generating the openapi go file..."
-    $(OPENAPI_GEN) ./api/$(API_VERSION)/ \
+	$(OPENAPI_GEN) ./api/$(API_VERSION)/ \
 	--output-pkg github.com/codeready-toolchain/api/api/$(API_VERSION) \
 	--output-file zz_generated.openapi.go \
 	--output-dir ./api/$(API_VERSION) \

--- a/make/generate.mk
+++ b/make/generate.mk
@@ -10,17 +10,6 @@ MEMBER_CLUSTER_CRDS:=useraccounts nstemplatesets memberstatuses idlers toolchain
 PATH_TO_CRD_BASES=config/crd/bases
 
 PROJECT_DIR := $(shell pwd)
-# openapi-gen requires the GOPATH env var be set and the codebase be present within it.
-# Let's not require $GOPATH be set up in the user's environment and the checkout be
-# placed in it.
-# Instead, fake it locally.
-FAKE_GOPATH=$(PROJECT_DIR)/.fake-gopath
-# The root of all codeready-toolchain repos in the GOPATH
-CRT_IN_GOPATH=$(FAKE_GOPATH)/src/github.com/codeready-toolchain
-# This gives the GOPATH as understood by the go compiler even if the env var is not explicitly set.
-# We use this to find the packages that are already downloaded locally to save on the network traffic
-# when persuading openapi-gen that our codebase is checked out under the GOPATH.
-LOCAL_GOPATH=`$(GO) env GOPATH`
 
 .PHONY: generate
 ## Generate deepcopy, openapi and CRD files after the API was modified


### PR DESCRIPTION
## Description
I forgot to clean the envs when we dropped the fake GOPATH hack in #474, sorry!

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **yes/no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#
