### PR TITLE
Remove CODE-OWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @MatousJobanek @xcoulon @alexeykazakov @rajivnathan @mfrancisc @rsoaresd @fbm3307 @metlos @jrosental


### PR DESCRIPTION
## Description
This PR is to remove CODEOWNERS file as it is not required now and keeping it creates an unnecessary overhead

## Checks
1. Did you run `make generate` target? **NA**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **NA**

3. In case of **new** CRD, did you the following? **NA*
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    
    Similar PRs : 
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/483
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1179
- member-operator: https://github.com/codeready-toolchain/member-operator/pull/681
- registration-service: https://github.com/codeready-toolchain/registration-service/pull/533
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1153
- ksctl: https://github.com/kubesaw/ksctl/pull/118
- workload-analyzer: https://github.com/codeready-toolchain/workload-analyzer/pull/216
- toolchain-cicd: https://github.com/codeready-toolchain/toolchain-cicd/pull/141
- sandboxctl: https://github.com/codeready-toolchain/sandboxctl/pull/41
- sandbox-sre: https://github.com/codeready-toolchain/sandbox-sre/pull/2464
- kubesaw.github.io: https://github.com/kubesaw/kubesaw.github.io/pull/14