### PR TITLE
drop setup-go step from govulcheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,11 +13,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v5
 
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-
     - name: Run govulncheck
       uses: codeready-toolchain/toolchain-cicd/govulncheck-action@master
       with:


### PR DESCRIPTION
duplicate with the one in composite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the security vulnerability scanning workflow in CI by removing a redundant environment setup step. This reduces pipeline time and maintenance overhead while preserving the existing vulnerability checks and configuration. No user-facing changes or feature impacts. Expect slightly faster and more reliable CI runs with the same coverage for security scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->