### PR TITLE
 SANDBOX-1769 | feature: specify integration types with constants

### DIFF
--- a/api/v1alpha1/toolchainconfig_types.go
+++ b/api/v1alpha1/toolchainconfig_types.go
@@ -4,6 +4,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// IntegrationName identifies a downstream service integration that can be
+// disabled via the ToolchainConfig CR.
+// +kubebuilder:validation:Enum=openshift;openshift-ai;devspaces;ansible-automation-platform;openshift-virtualization
+type IntegrationName string
+
+const (
+	IntegrationOpenShift                 IntegrationName = "openshift"
+	IntegrationOpenShiftAI               IntegrationName = "openshift-ai"
+	IntegrationDevSpaces                 IntegrationName = "devspaces"
+	IntegrationAnsibleAutomationPlatform IntegrationName = "ansible-automation-platform"
+	IntegrationOpenShiftVirtualization   IntegrationName = "openshift-virtualization"
+)
+
 // These are valid conditions of a ToolchainConfig
 const (
 	ToolchainConfigSyncComplete     ConditionType = "SyncComplete"
@@ -256,7 +269,7 @@ type RegistrationServiceConfig struct {
 	// considered enabled. Only listed integrations are hidden.
 	// +optional
 	// +listType=set
-	DisabledIntegrations []string `json:"disabledIntegrations,omitempty"`
+	DisabledIntegrations []IntegrationName `json:"disabledIntegrations,omitempty"`
 }
 
 // RegistrationServiceAnalyticsConfig contains the subset of registration service configuration parameters related to analytics

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1929,7 +1929,7 @@ func (in *RegistrationServiceConfig) DeepCopyInto(out *RegistrationServiceConfig
 	}
 	if in.DisabledIntegrations != nil {
 		in, out := &in.DisabledIntegrations, &out.DisabledIntegrations
-		*out = make([]string, len(*in))
+		*out = make([]IntegrationName, len(*in))
 		copy(*out, *in)
 	}
 }


### PR DESCRIPTION
## Description
The goal is to avoid having misconfigurations by having a wrong value in the "disabledIntegrations" field. Kubernetes will be aware of which are the accepted values to avoid those misconfigurations.

## Related PRs

- https://github.com/codeready-toolchain/api/pull/502
  - https://github.com/codeready-toolchain/api/pull/503 (this one)
- https://github.com/codeready-toolchain/toolchain-common/pull/524
- https://github.com/codeready-toolchain/host-operator/pull/1255
- https://github.com/codeready-toolchain/host-operator/pull/1256
- https://github.com/codeready-toolchain/registration-service/pull/590
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1274

## Checks
1. Did you run `make generate` target? **yes/no**

Yes.

3. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes/no**

No.

5. In case of **new** CRD, did you the following? **yes/no**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

It's not a new CRD.

6. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#
    - member-operator: https://github.com/codeready-toolchain/member-operator/pull/#


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized integration types for configuration: OpenShift, OpenShift AI, DevSpaces, Ansible Automation Platform, and OpenShift Virtualization.

* **Improvements**
  * Integration configurations are now validated against predefined types, preventing invalid values and ensuring configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->