### PR TITLE
fix: make account verifier flag enum

### DIFF
--- a/api/v1alpha1/docs/apiref.adoc
+++ b/api/v1alpha1/docs/apiref.adoc
@@ -2139,7 +2139,10 @@ considered enabled. Only listed integrations are hidden. + |  | Optional: \{} +
 
 | *`accountVerifierURL`* __string__ | AccountVerifierURL is the URL used to call the account verifier service + |  | Optional: \{} +
 
-| *`accountVerifierEnabled`* __boolean__ | AccountVerifierEnabled controls whether the registration service acts on responses from the account-verifier service. + |  | Optional: \{} +
+| *`accountVerifierMode`* __string__ | AccountVerifierMode controls how the registration service handles responses from the account-verifier service. +
+Valid values are "disabled" (do not call the verifier), "log" (call but only log the response), +
+and "enabled" (call and enforce the response). Defaults to "log". + |  | Enum: [disabled log enabled] +
+Optional: \{} +
 
 |===
 

--- a/api/v1alpha1/toolchainconfig_types.go
+++ b/api/v1alpha1/toolchainconfig_types.go
@@ -262,9 +262,12 @@ type RegistrationServiceConfig struct {
 	// +optional
 	AccountVerifierURL *string `json:"accountVerifierURL,omitempty"`
 
-	// AccountVerifierEnabled controls whether the registration service acts on responses from the account-verifier service.
+	// AccountVerifierMode controls how the registration service handles responses from the account-verifier service.
+	// Valid values are "disabled" (do not call the verifier), "log" (call but only log the response),
+	// and "enabled" (call and enforce the response). Defaults to "log".
 	// +optional
-	AccountVerifierEnabled *bool `json:"accountVerifierEnabled,omitempty"`
+	// +kubebuilder:validation:Enum=disabled;log;enabled
+	AccountVerifierMode *string `json:"accountVerifierMode,omitempty"`
 }
 
 // RegistrationServiceAnalyticsConfig contains the subset of registration service configuration parameters related to analytics

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1937,9 +1937,9 @@ func (in *RegistrationServiceConfig) DeepCopyInto(out *RegistrationServiceConfig
 		*out = new(string)
 		**out = **in
 	}
-	if in.AccountVerifierEnabled != nil {
-		in, out := &in.AccountVerifierEnabled, &out.AccountVerifierEnabled
-		*out = new(bool)
+	if in.AccountVerifierMode != nil {
+		in, out := &in.AccountVerifierMode, &out.AccountVerifierMode
+		*out = new(string)
 		**out = **in
 	}
 }

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -2658,10 +2658,10 @@ func schema_codeready_toolchain_api_api_v1alpha1_RegistrationServiceConfig(ref c
 							Format:      "",
 						},
 					},
-					"accountVerifierEnabled": {
+					"accountVerifierMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AccountVerifierEnabled controls whether the registration service acts on responses from the account-verifier service.",
-							Type:        []string{"boolean"},
+							Description: "AccountVerifierMode controls how the registration service handles responses from the account-verifier service. Valid values are \"disabled\" (do not call the verifier), \"log\" (call but only log the response), and \"enabled\" (call and enforce the response). Defaults to \"log\".",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},


### PR DESCRIPTION
## Description
Change account verifier flag to enum so it supports: enabled/disabled/log config options 

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator)? **yes**

3. In case of **new** CRD, did you the following? **N/A**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account verifier configuration now supports operational modes (`disabled`, `log`, `enabled`) instead of a binary toggle. The default mode is `log`. This enhancement provides more granular control over account verification behavior to align with your deployment requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->