### PR TITLE
feat: add rejected usersignup state

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -168,7 +168,7 @@ const (
 	// UserSignupStateBanned - If this state is set by an admin then the user's account will be banned.
 	UserSignupStateBanned = UserSignupState("banned")
 
-	// UserSignupStateRejected - If this state is set, the user was rejected by the account verifier
+	// UserSignupStateRejected - If this state is set, the user was rejected
 	// and their account will not be provisioned.
 	UserSignupStateRejected = UserSignupState("rejected")
 )

--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -77,6 +77,8 @@ const (
 	UserSignupStateLabelValueDeactivated = "deactivated"
 	// UserSignupStateLabelValueBanned is used for identifying that the UserSignup is banned
 	UserSignupStateLabelValueBanned = "banned"
+	// UserSignupStateLabelValueRejected is used for identifying that the UserSignup was rejected
+	UserSignupStateLabelValueRejected = "rejected"
 
 	// Status condition reasons
 	UnableToCreateSpaceBinding                     = "UnableToCreateSpaceBinding"
@@ -105,6 +107,7 @@ const (
 	UserSignupPendingApprovalReason            = "PendingApproval"
 	UserSignupUserBanningReason                = "Banning"
 	UserSignupUserBannedReason                 = "Banned"
+	UserSignupUserRejectedReason               = "Rejected"
 	UserSignupFailedToReadBannedUsersReason    = "FailedToReadBannedUsers"
 	UserSignupMissingUserEmailReason           = "MissingUserEmail"
 	UserSignupMissingUserEmailAnnotationReason = "MissingUserEmailAnnotation"
@@ -164,6 +167,10 @@ const (
 
 	// UserSignupStateBanned - If this state is set by an admin then the user's account will be banned.
 	UserSignupStateBanned = UserSignupState("banned")
+
+	// UserSignupStateRejected - If this state is set, the user was rejected by the account verifier
+	// and their account will not be provisioned.
+	UserSignupStateRejected = UserSignupState("rejected")
 )
 
 type UserSignupState string


### PR DESCRIPTION
## Description
wrt https://github.com/codeready-toolchain/registration-service/pull/594#discussion_r3288799346

## Checks
1. Did you run `make generate` target? **yes/no**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **no**

3. In case of **new** CRD, did you the following? **N/A**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/#



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking rejected user signups, enabling the system to properly manage and label rejected signup states throughout the user lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->