### PR TITLE
account-verifier response type and values

### DIFF
--- a/api/v1alpha1/usersignup_types.go
+++ b/api/v1alpha1/usersignup_types.go
@@ -178,8 +178,33 @@ const (
 	// UserSignupStateRejected - If this state is set, the user was rejected
 	// and their account will not be provisioned.
 	UserSignupStateRejected = UserSignupState("rejected")
+
+	// ###############################################################################
+	//    Account Verifier accepted verdict values
+	// ###############################################################################
+
+	// AccountVerifierResultRejected instructs that the UserSignup should be put into rejected state
+	AccountVerifierResultRejected AccountVerifierResult = "rejected"
+
+	// AccountVerifierResultPhoneVerification instructs that the UserSignup should be put into verification-required state
+	AccountVerifierResultPhoneVerification AccountVerifierResult = "phone_verification"
+
+	// AccountVerifierResultApproved instructs that the UserSignup can be approved
+	AccountVerifierResultApproved AccountVerifierResult = "approved"
 )
 
+type AccountVerifierResult string
+
+type AccountVerifierResponse struct {
+	Result  AccountVerifierResult   `json:"result"`
+	Reasons []AccountVerifierReason `json:"reasons"`
+	Error   string                  `json:"error"`
+}
+
+type AccountVerifierReason struct {
+	Check  string `json:"check"`
+	Detail string `json:"detail"`
+}
 type UserSignupState string
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.


### PR DESCRIPTION
let's move it to API to ensure that we use the same values at both places

https://redhat-internal.slack.com/archives/C061H0CGYBZ/p1782218221030119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive account verification support with multiple verdict types (approved, rejected, phone verification required) and structured response handling for detailed feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->