### PR TITLE
SANDBOX-1889: change default phoneLookupMode from log to disabled

### DIFF
--- a/api/v1alpha1/docs/apiref.adoc
+++ b/api/v1alpha1/docs/apiref.adoc
@@ -2339,7 +2339,7 @@ See https://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html for deta
 
 | *`phoneLookupMode`* __xref:{anchor_prefix}-github-com-codeready-toolchain-api-api-v1alpha1-phonelookupmode[$$PhoneLookupMode$$]__ | PhoneLookupMode controls how the registration service handles Twilio Lookup v2 phone risk checks. +
 Valid values are "disabled" (skip Lookup entirely), "log" (call Lookup and store results but don't block), +
-and "enabled" (call Lookup and enforce blocking). Defaults to "log". + | log | Enum: [disabled log enabled] +
+and "enabled" (call Lookup and enforce blocking). Defaults to "disabled". + | disabled | Enum: [disabled log enabled] +
 Optional: \{} +
 
 | *`phoneLookupExcludedCountries`* __string array__ | PhoneLookupExcludedCountries is a list of ISO 3166-1 alpha-2 country codes (e.g. ["CA", "US"]) +

--- a/api/v1alpha1/toolchainconfig_types.go
+++ b/api/v1alpha1/toolchainconfig_types.go
@@ -399,9 +399,9 @@ type RegistrationServiceVerificationConfig struct {
 
 	// PhoneLookupMode controls how the registration service handles Twilio Lookup v2 phone risk checks.
 	// Valid values are "disabled" (skip Lookup entirely), "log" (call Lookup and store results but don't block),
-	// and "enabled" (call Lookup and enforce blocking). Defaults to "log".
+	// and "enabled" (call Lookup and enforce blocking). Defaults to "disabled".
 	// +optional
-	// +kubebuilder:default="log"
+	// +kubebuilder:default="disabled"
 	PhoneLookupMode *PhoneLookupMode `json:"phoneLookupMode,omitempty"`
 
 	// PhoneLookupExcludedCountries is a list of ISO 3166-1 alpha-2 country codes (e.g. ["CA", "US"])

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -2947,7 +2947,7 @@ func schema_codeready_toolchain_api_api_v1alpha1_RegistrationServiceVerification
 					},
 					"phoneLookupMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PhoneLookupMode controls how the registration service handles Twilio Lookup v2 phone risk checks. Valid values are \"disabled\" (skip Lookup entirely), \"log\" (call Lookup and store results but don't block), and \"enabled\" (call Lookup and enforce blocking). Defaults to \"log\".",
+							Description: "PhoneLookupMode controls how the registration service handles Twilio Lookup v2 phone risk checks. Valid values are \"disabled\" (skip Lookup entirely), \"log\" (call Lookup and store results but don't block), and \"enabled\" (call Lookup and enforce blocking). Defaults to \"disabled\".",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
## Description
Update the default value for phoneLookupMode to "disabled" . Production and staging are unaffected as they already set phoneLookupMode to "enabled" explicitly.

## Checks
1. Did you run `make generate` target? **yes**

2. Did `make generate` change anything in other projects (host-operator, member-operator)? **yes**

3. In case of **new** CRD, did you the following? **NA**
    - make/generate.mk in this repository
    - `resources/setup/roles/host.yaml` in the sandbox-sre repository
    - `PROJECT` file: https://github.com/codeready-toolchain/host-operator/blob/master/PROJECT
    - `CSV` file: https://github.com/codeready-toolchain/host-operator/blob/master/config/manifests/bases/host-operator.clusterserviceversion.yaml

4. In case other projects are changed, please provides PR links.
    - host-operator: https://github.com/codeready-toolchain/host-operator/pull/1274

registration service: https://github.com/codeready-toolchain/registration-service/pull/604
Toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1292
    
Assisted by : Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default setting for phone number lookup verification from `log` to `disabled`.
  * Clarified the available phone lookup modes so the behavior is easier to understand when configuring verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->