### PR TITLE
chore: update golangci action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,9 +25,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.1.6
-        skip-pkg-cache: true
-        skip-build-cache: true
+        version: v2.12.2
         args: --config=./.golangci.yml --verbose
 
 


### PR DESCRIPTION
update to golangci-lint 2.12.2 and remove the obsolete `skip-pkg-cache` and `skip-build-cache` (because the cache related to Go itself is already handled by `actions/setup-go`)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code quality checks to use a newer linting tool version.
  * Improved validation by enabling package and build cache checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->