### PR TITLE
chore: remove the 'check-go-format' make goal

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -16,17 +16,6 @@ format-go-code:
 # would be a syntax error — find -exec requires either + or \; as a terminator.
 	$(Q)find . -name '*.go' -not -path '*/vendor/*' -not -path '*/.git/*' -exec gofmt -s -l -w {} +
 
-.PHONY: check-go-format
-## Verify the formatting defined by 'gofmt'
-check-go-format:
-	$(Q)find . -name '*.go' -not -path '*/vendor/*' -not -path '*/.git/*' -exec gofmt -s -l {} + 2>&1 \
-		| tee $(OUT_DIR)/gofmt-errors \
-		| read \
-	&& echo "ERROR: These files differ from gofmt's style (run 'make format-go-code' to fix this):" \
-	&& cat $(OUT_DIR)/gofmt-errors \
-	&& exit 1 \
-	|| true
-
 .PHONY: build
 ## Build
 build:


### PR DESCRIPTION
not needed anymore, covered by golangci-lint

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `check-go-format` build command and its formatting validation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->